### PR TITLE
Update Parser.php

### DIFF
--- a/src/eXorus/PhpMimeMailParser/Parser.php
+++ b/src/eXorus/PhpMimeMailParser/Parser.php
@@ -225,7 +225,7 @@ class Parser
         );
         if (in_array($type, array_keys($mime_types))) {
             foreach ($this->parts as $part) {
-                if ($this->getPartContentType($part) == $mime_types[$type] && !$this->getPartContentDisposition($part)) {
+                if ($this->getPartContentType($part) == $mime_types[$type] && $this->getPartContentDisposition($part) != 'attachment') {
                     $headers = $this->getPartHeaders($part);
                     $encodingType = array_key_exists('content-transfer-encoding', $headers) ? $headers['content-transfer-encoding'] : '';
 


### PR DESCRIPTION
The parser will only ignore explicit attachments when looking for the message body. I've encountered some emails that send plain and html body parts with "Content-Disposition: inline". The previous code ignored those inline parts.
