### PR TITLE
Update Parser.php

### DIFF
--- a/src/eXorus/PhpMimeMailParser/Parser.php
+++ b/src/eXorus/PhpMimeMailParser/Parser.php
@@ -428,12 +428,12 @@ class Parser
         if (is_array($input)) {
 
             foreach ($input as &$element) {
-                $element = iconv_mime_decode($element, 0, 'UTF-8');
+                $element = iconv_mime_decode($element, 2, 'UTF-8');
             }
             return $input;
 
         } else {
-            return iconv_mime_decode($input, 0, 'UTF-8');
+            return iconv_mime_decode($input, 2, 'UTF-8');
         }
     }
 


### PR DESCRIPTION
Some headers may be malformed strings. Using mode 2 (ICONV_MIME_DECODE_CONTINUE_ON_ERROR) iconv_mime_decode_headers() attempts to ignore any grammatical errors and continue to process a given header. Previously it would stop processing the header and issue a warning.
