### PR TITLE
Parser.php : make saveAttachments() return saved attachments paths

### DIFF
--- a/src/eXorus/PhpMimeMailParser/Parser.php
+++ b/src/eXorus/PhpMimeMailParser/Parser.php
@@ -279,7 +279,7 @@ class Parser
     public function saveAttachments($attach_dir)
     {
         $attachments = $this->getAttachments();
-        $attachments_paths = [];
+        $attachments_paths = array();
         
         if (empty($attachments)) {
             return false;


### PR DESCRIPTION
This is helpful to save the number and final paths of attachments...
