### PR TITLE
Remove PHP 5.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # php-mime-mail-parser
 
-Fully Tested Mailparse Extension Wrapper for PHP 5.3+
+Fully Tested Mailparse Extension Wrapper for PHP 5.4+
 
 
 [![Latest Stable Version](https://poser.pugx.org/exorus/php-mime-mail-parser/v/stable.svg)](https://packagist.org/packages/exorus/php-mime-mail-parser) [![Total Downloads](https://poser.pugx.org/exorus/php-mime-mail-parser/downloads.svg)](https://packagist.org/packages/exorus/php-mime-mail-parser) [![Latest Unstable Version](https://poser.pugx.org/exorus/php-mime-mail-parser/v/unstable.svg)](https://packagist.org/packages/exorus/php-mime-mail-parser) [![License](https://poser.pugx.org/exorus/php-mime-mail-parser/license.svg)](https://packagist.org/packages/exorus/php-mime-mail-parser)
@@ -27,7 +27,6 @@ To install this library, run the command below and you will get the latest versi
 
 The following versions of PHP are supported by this version.
 
-* PHP 5.3
 * PHP 5.4
 * PHP 5.5
 * PHP 5.6

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "exorus/php-mime-mail-parser",
     "type": "library",
-    "description": "Fully Tested Mailparse Extension Wrapper for PHP 5.3+",
+    "description": "Fully Tested Mailparse Extension Wrapper for PHP 5.4+",
     "keywords": ["mime", "mail", "mailparse", "MimeMailParser"],
     "homepage": "https://github.com/php-mime-mail-parser/php-mime-mail-parser",
     "license": "MIT",
@@ -42,7 +42,7 @@
         "url":"https://github.com/php-mime-mail-parser/php-mime-mail-parser.git"
     },
     "require": {
-        "php":           ">=5.3.0",
+        "php":           ">=5.4.0",
         "ext-mailparse": "*"
     },
     "require-dev": {

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -5,7 +5,7 @@ namespace eXorus\PhpMimeMailParser;
 /**
  * Attachment of php-mime-mail-parser
  *
- * Fully Tested Mailparse Extension Wrapper for PHP 5.3+
+ * Fully Tested Mailparse Extension Wrapper for PHP 5.4+
  *
  */
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -9,7 +9,7 @@ use eXorus\PhpMimeMailParser\Contracts\CharsetManager;
 /**
  * Parser of php-mime-mail-parser
  *
- * Fully Tested Mailparse Extension Wrapper for PHP 5.3+
+ * Fully Tested Mailparse Extension Wrapper for PHP 5.4+
  *
  */
 

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -36,7 +36,7 @@ namespace eXorus\PhpMimeMailParser {
     /**
      * ExceptionTest of php-mime-mail-parser
      *
-     * Fully Tested Mailparse Extension Wrapper for PHP 5.3+
+     * Fully Tested Mailparse Extension Wrapper for PHP 5.4+
      *
      */
 

--- a/test/ParserTest.php
+++ b/test/ParserTest.php
@@ -8,7 +8,7 @@ use eXorus\PhpMimeMailParser\Exception;
 /**
  * Test Parser of php-mime-mail-parser
  *
- * Fully Tested Mailparse Extension Wrapper for PHP 5.3+
+ * Fully Tested Mailparse Extension Wrapper for PHP 5.4+
  *
  */
 class ParserTest extends \PHPUnit_Framework_TestCase


### PR DESCRIPTION
Now that 5.3 is EOL (2014-08-14) it is no longer receiving security updates and everyone should be encouraged to use a more up to date and secure version