### PR TITLE
Update the namespace to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Fully Tested Mailparse Extension Wrapper for PHP 5.3+
 
 
-[![Latest Stable Version](https://poser.pugx.org/exorus/php-mime-mail-parser/v/stable.svg)](https://packagist.org/packages/exorus/php-mime-mail-parser) [![Total Downloads](https://poser.pugx.org/exorus/php-mime-mail-parser/downloads.svg)](https://packagist.org/packages/exorus/php-mime-mail-parser) [![Latest Unstable Version](https://poser.pugx.org/exorus/php-mime-mail-parser/v/unstable.svg)](https://packagist.org/packages/exorus/php-mime-mail-parser) [![License](https://poser.pugx.org/exorus/php-mime-mail-parser/license.svg)](https://packagist.org/packages/exorus/php-mime-mail-parser)
+[![Latest Stable Version](https://poser.pugx.org/php-mime-mail-parser/php-mime-mail-parser/v/stable.svg)](https://packagist.org/packages/php-mime-mail-parser/php-mime-mail-parser) [![Total Downloads](https://poser.pugx.org/php-mime-mail-parser/php-mime-mail-parser/downloads.svg)](https://packagist.org/packages/php-mime-mail-parser/php-mime-mail-parser) [![Latest Unstable Version](https://poser.pugx.org/php-mime-mail-parser/php-mime-mail-parser/v/unstable.svg)](https://packagist.org/packages/php-mime-mail-parser/php-mime-mail-parser) [![License](https://poser.pugx.org/php-mime-mail-parser/php-mime-mail-parser/license.svg)](https://packagist.org/packages/php-mime-mail-parser/php-mime-mail-parser)
 
 > **Maintainer:** Visit my blog [Vincent Dauce](http://vincent.dauce.fr).
 
@@ -21,7 +21,7 @@ Easy way with [Composer](https://getcomposer.org/) ;)
 
 To install this library, run the command below and you will get the latest version
 
-	composer require exorus/php-mime-mail-parser
+	composer require php-mime-mail-parser/php-mime-mail-parser
 
 ## Requirements
 
@@ -46,7 +46,7 @@ And imap functions with :
 require_once __DIR__.'/vendor/autoload.php';
 
 $path = 'path/to/mail.txt';
-$Parser = new eXorus\PhpMimeMailParser\Parser();
+$Parser = new PhpMimeMailParser\Parser();
 
 //There are three input methods of the mime mail to be parsed
 //specify a file path to the mime mail :
@@ -91,5 +91,4 @@ To add issue, please provide the raw email with it.
 
 ### License
 
-The exorus/php-mime-mail-parser is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT)
-
+The php-mime-mail-parser/php-mime-mail-parser is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT)

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "exorus/php-mime-mail-parser",
+    "name": "php-mime-mail-parser/php-mime-mail-parser",
     "type": "library",
     "description": "Fully Tested Mailparse Extension Wrapper for PHP 5.3+",
     "keywords": ["mime", "mail", "mailparse", "MimeMailParser"],
@@ -50,7 +50,11 @@
         "satooshi/php-coveralls":       "0.*",
         "squizlabs/PHP_CodeSniffer":    "2.*"
     },
+    "replace": {
+        "exorus/php-mime-mail-parser":   "*",
+        "messaged/php-mime-mail-parser": "*"
+    },
     "autoload": {
-        "psr-4": { "eXorus\\PhpMimeMailParser\\": "src/" }
+        "psr-4": { "PhpMimeMailParser\\": "src/" }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit colors="true">
     <testsuites>
-        <testsuite name="eXorus PhpMimeMailParser Test Suite">
+        <testsuite name="PhpMimeMailParser Test Suite">
             <directory>./test</directory>
         </testsuite>
     </testsuites>

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eXorus\PhpMimeMailParser;
+namespace PhpMimeMailParser;
 
 /**
  * Attachment of php-mime-mail-parser

--- a/src/Charset.php
+++ b/src/Charset.php
@@ -1,6 +1,6 @@
-<?php namespace eXorus\PhpMimeMailParser;
+<?php namespace PhpMimeMailParser;
 
-use eXorus\PhpMimeMailParser\Contracts\CharsetManager;
+use PhpMimeMailParser\Contracts\CharsetManager;
 
 class Charset implements CharsetManager
 {

--- a/src/Contracts/CharsetManager.php
+++ b/src/Contracts/CharsetManager.php
@@ -1,4 +1,4 @@
-<?php namespace eXorus\PhpMimeMailParser\Contracts;
+<?php namespace PhpMimeMailParser\Contracts;
 
 interface CharsetManager
 {

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eXorus\PhpMimeMailParser;
+namespace PhpMimeMailParser;
 
 class Exception extends \RuntimeException
 {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace eXorus\PhpMimeMailParser;
+namespace PhpMimeMailParser;
 
-use eXorus\PhpMimeMailParser\Attachment;
-use eXorus\PhpMimeMailParser\Exception;
-use eXorus\PhpMimeMailParser\Contracts\CharsetManager;
+use PhpMimeMailParser\Attachment;
+use PhpMimeMailParser\Exception;
+use PhpMimeMailParser\Contracts\CharsetManager;
 
 /**
  * Parser of php-mime-mail-parser

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -2,16 +2,16 @@
 
 namespace {
 
-    use eXorus\PhpMimeMailParser\Parser;
-    use eXorus\PhpMimeMailParser\Attachment;
-    use eXorus\PhpMimeMailParser\Exception;
+    use PhpMimeMailParser\Parser;
+    use PhpMimeMailParser\Attachment;
+    use PhpMimeMailParser\Exception;
 
     // This allow us to configure the behavior of the "global mock"
     $mockTmpFile = false;
     $mockFopen = false;
 }
 
-namespace eXorus\PhpMimeMailParser {
+namespace PhpMimeMailParser {
 
     function tmpfile()
     {

--- a/test/ParserTest.php
+++ b/test/ParserTest.php
@@ -1,9 +1,9 @@
 <?php
-namespace eXorus\PhpMimeMailParser;
+namespace PhpMimeMailParser;
 
-use eXorus\PhpMimeMailParser\Parser;
-use eXorus\PhpMimeMailParser\Attachment;
-use eXorus\PhpMimeMailParser\Exception;
+use PhpMimeMailParser\Parser;
+use PhpMimeMailParser\Attachment;
+use PhpMimeMailParser\Exception;
 
 /**
  * Test Parser of php-mime-mail-parser


### PR DESCRIPTION
Now that the project is under it's own namespace on github, shouldn't it be under the same namespace on packagist and in the code?

If accepted, this pr would require a version bump to 2.0 so maybe we could bundle in some other improvements too? And if support for 5.3 is dropped we could use some of the features introduced in 5.4
