### PR TITLE
better to use the mb_convert_encodeing than iconv.

### DIFF
--- a/src/Charset.php
+++ b/src/Charset.php
@@ -323,9 +323,9 @@ class Charset implements CharsetManager
         if (strtolower($charset) == 'utf-8' || strtolower($charset) == 'us-ascii') {
             return $encodedString;
         } elseif (function_exists("mb_convert_encoding")) {
-            return mb_convert_encoding($encodedString, 'UTF-8',$this->getCharsetAlias($charset));
+            return mb_convert_encoding($encodedString, 'UTF-8', $this->getCharsetAlias($charset));
         } else {
-            return iconv($this->getCharsetAlias($charset), 'UTF-8//TRANSLIT', $encodedString);     
+            return iconv($this->getCharsetAlias($charset), 'UTF-8//TRANSLIT', $encodedString);
         }
     }
 

--- a/src/Charset.php
+++ b/src/Charset.php
@@ -322,7 +322,8 @@ class Charset implements CharsetManager
     {
         if (strtolower($charset) == 'utf-8' || strtolower($charset) == 'us-ascii') {
             return $encodedString;
-        } elseif (function_exists('mb_convert_encoding') && in_array($this->getCharsetAlias($charset), array('ISO-2022-JP', 'Shift_JIS', 'EUC-JP')) {
+        } elseif (function_exists('mb_convert_encoding')
+            && in_array($this->getCharsetAlias($charset), array('ISO-2022-JP', 'Shift_JIS', 'EUC-JP')) {
             return mb_convert_encoding($encodedString, 'UTF-8', $this->getCharsetAlias($charset));
         } else {
             return iconv($this->getCharsetAlias($charset), 'UTF-8//TRANSLIT', $encodedString);

--- a/src/Charset.php
+++ b/src/Charset.php
@@ -322,8 +322,10 @@ class Charset implements CharsetManager
     {
         if (strtolower($charset) == 'utf-8' || strtolower($charset) == 'us-ascii') {
             return $encodedString;
-        } else {
+        } elseif (function_exists("mb_convert_encoding")) {
             return mb_convert_encoding($encodedString, 'UTF-8',$this->getCharsetAlias($charset));
+        } else {
+            return iconv($this->getCharsetAlias($charset), 'UTF-8//TRANSLIT', $encodedString);     
         }
     }
 

--- a/src/Charset.php
+++ b/src/Charset.php
@@ -322,7 +322,7 @@ class Charset implements CharsetManager
     {
         if (strtolower($charset) == 'utf-8' || strtolower($charset) == 'us-ascii') {
             return $encodedString;
-        } elseif (function_exists('mb_convert_encoding')) {
+        } elseif (function_exists('mb_convert_encoding') && in_array($this->getCharsetAlias($charset), array('ISO-2022-JP', 'Shift_JIS', 'EUC-JP')) {
             return mb_convert_encoding($encodedString, 'UTF-8', $this->getCharsetAlias($charset));
         } else {
             return iconv($this->getCharsetAlias($charset), 'UTF-8//TRANSLIT', $encodedString);

--- a/src/Charset.php
+++ b/src/Charset.php
@@ -323,7 +323,7 @@ class Charset implements CharsetManager
         if (strtolower($charset) == 'utf-8' || strtolower($charset) == 'us-ascii') {
             return $encodedString;
         } else {
-            return iconv($this->getCharsetAlias($charset), 'UTF-8//TRANSLIT', $encodedString);
+            return mb_convert_encoding($encodedString, 'UTF-8',$this->getCharsetAlias($charset));
         }
     }
 

--- a/src/Charset.php
+++ b/src/Charset.php
@@ -323,7 +323,7 @@ class Charset implements CharsetManager
         if (strtolower($charset) == 'utf-8' || strtolower($charset) == 'us-ascii') {
             return $encodedString;
         } elseif (function_exists('mb_convert_encoding')
-            && in_array($this->getCharsetAlias($charset), array('ISO-2022-JP', 'Shift_JIS', 'EUC-JP')) {
+            && in_array($this->getCharsetAlias($charset), array('ISO-2022-JP', 'Shift_JIS', 'EUC-JP'))) {
             return mb_convert_encoding($encodedString, 'UTF-8', $this->getCharsetAlias($charset));
         } else {
             return iconv($this->getCharsetAlias($charset), 'UTF-8//TRANSLIT', $encodedString);

--- a/src/Charset.php
+++ b/src/Charset.php
@@ -322,7 +322,7 @@ class Charset implements CharsetManager
     {
         if (strtolower($charset) == 'utf-8' || strtolower($charset) == 'us-ascii') {
             return $encodedString;
-        } elseif (function_exists("mb_convert_encoding")) {
+        } elseif (function_exists('mb_convert_encoding')) {
             return mb_convert_encoding($encodedString, 'UTF-8', $this->getCharsetAlias($charset));
         } else {
             return iconv($this->getCharsetAlias($charset), 'UTF-8//TRANSLIT', $encodedString);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -121,10 +121,6 @@ class Parser
     public function setText($data)
     {
         $this->resource = \mailparse_msg_create();
-
-        if(substr($data,-1)!="\n"){
-            $data .= "\n";
-        }
         // does not parse incrementally, fast memory hog might explode
         mailparse_msg_parse($this->resource, $data);
         $this->data = $data;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -121,6 +121,10 @@ class Parser
     public function setText($data)
     {
         $this->resource = \mailparse_msg_create();
+
+        if(substr($data,-1)!="\n"){
+            $data .= "\n";
+        }
         // does not parse incrementally, fast memory hog might explode
         mailparse_msg_parse($this->resource, $data);
         $this->data = $data;


### PR DESCRIPTION
In Japanease,message(iso-2022-jp & quoted-printable) will be empty.
