### PR TITLE
Added method getHeaders

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -166,6 +166,31 @@ class Parser
     }
 
     /**
+     * Retrieve all mail headers
+     * @return Array
+     */
+    public function getHeaders()
+    {
+        if (isset($this->parts[1])) {
+            $headers = $this->getPart('headers', $this->parts[1]);
+            foreach ($headers as $name => &$value) {
+                if (is_array($value)) {
+                    foreach ($value as &$v) {
+                        $v = $this->decodeSingleHeader($v);
+                    }
+                } else {
+                    $value = $this->decodeSingleHeader($value);
+                }
+            }
+            return $headers;
+        } else {
+            throw new \Exception(
+                'setPath() or setText() or setStream() must be called before retrieving email headers.'
+            );
+        }
+    }
+
+    /**
      * Returns the email message body in the specified format
      * @return Mixed String Body or False if not found
      * @param $type String text or html or htmlEmbedded
@@ -377,9 +402,19 @@ class Parser
     {
         //Sometimes we have 2 label From so we take only the first
         if (is_array($input)) {
-            $input = $input[0];
+            return $this->decodeSingleHeader($input[0]);
         }
 
+        return $this->decodeSingleHeader($input);
+    }
+
+    /**
+     * Decodes a single header (= string)
+     * @param string
+     * @return string
+     */
+    private function decodeSingleHeader($input)
+    {
         // Remove white space between encoded-words
         $input = preg_replace('/(=\?[^?]+\?(q|b)\?[^?]*\?=)(\s)+=\?/i', '\1=?', $input);
 

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -63,6 +63,16 @@ namespace PhpMimeMailParser {
 
         /**
          * @expectedException        Exception
+         * @expectedExceptionMessage setPath() or setText() or setStream() must be called before
+         */
+        public function testGetHeaders()
+        {
+            $Parser = new Parser();
+            $Parser->getHeaders();
+        }
+
+        /**
+         * @expectedException        Exception
          * @expectedExceptionMessage Invalid type specified for getMessageBody(). "type" can either be text or html.
          */
         public function testgetMessageBody()

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -470,15 +470,19 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
         //Test Header : subject
         $this->assertEquals($subjectExpected, $Parser->getHeader('subject'));
+        $this->assertArrayHasKey('subject', $Parser->getHeaders());
 
         //Test Header : from
         $this->assertEquals($fromExpected, $Parser->getHeader('from'));
+        $this->assertArrayHasKey('from', $Parser->getHeaders());
 
         //Test Header : to
         $this->assertEquals($toExpected, $Parser->getHeader('to'));
+        $this->assertArrayHasKey('to', $Parser->getHeaders());
 
         //Test Invalid Header
         $this->assertFalse($Parser->getHeader('azerty'));
+        $this->assertArrayNotHasKey('azerty', $Parser->getHeaders());
 
         //Test  Body : text
         if ($textExpected[0] == 'COUNT') {
@@ -582,16 +586,20 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
         //Test Header : subject
         $this->assertEquals($subjectExpected, $Parser->getHeader('subject'));
+        $this->assertArrayHasKey('subject', $Parser->getHeaders());
 
         //Test Header : from
         $this->assertEquals($fromExpected, $Parser->getHeader('from'));
+        $this->assertArrayHasKey('from', $Parser->getHeaders());
 
         //Test Header : to
         $this->assertEquals($toExpected, $Parser->getHeader('to'));
+        $this->assertArrayHasKey('to', $Parser->getHeaders());
 
         //Test Invalid Header
         $this->assertFalse($Parser->getHeader('azerty'));
-        
+        $this->assertArrayNotHasKey('azerty', $Parser->getHeaders());
+
         //Test  Body : text
         if ($textExpected[0] == 'COUNT') {
             $this->assertEquals($textExpected[1], substr_count($Parser->getMessageBody('text'), $textExpected[2]));
@@ -695,16 +703,20 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
         //Test Header : subject
         $this->assertEquals($subjectExpected, $Parser->getHeader('subject'));
+        $this->assertArrayHasKey('subject', $Parser->getHeaders());
 
         //Test Header : from
         $this->assertEquals($fromExpected, $Parser->getHeader('from'));
+        $this->assertArrayHasKey('from', $Parser->getHeaders());
 
         //Test Header : to
         $this->assertEquals($toExpected, $Parser->getHeader('to'));
+        $this->assertArrayHasKey('to', $Parser->getHeaders());
 
         //Test Invalid Header
         $this->assertFalse($Parser->getHeader('azerty'));
-        
+        $this->assertArrayNotHasKey('azerty', $Parser->getHeaders());
+
         //Test  Body : text
         if ($textExpected[0] == 'COUNT') {
             $this->assertEquals($textExpected[1], substr_count($Parser->getMessageBody('text'), $textExpected[2]));


### PR DESCRIPTION
(+ splitted decodeHeader so it doesn’t remove multi-value headers)

In a project I needed the ability to fetch all headers. Let me know what you think of this.

Best,
Nicolas