### PR TITLE
Add getRawHeader() method to allow retrieving headers without charset conversion

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -173,7 +173,7 @@ class Parser
     public function getHeader($name)
     {
         $rawHeader = $this->getRawHeader($name);
-        if($rawHeader === false) {
+        if ($rawHeader === false) {
             return false;
         }
         return $this->decodeHeader($rawHeader);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -149,20 +149,34 @@ class Parser
     }
 
     /**
+     * Retrieve a specific Email Header, without charset conversion.
+     * @return String
+     * @param $name String Header name
+     */
+    public function getRawHeader($name)
+    {
+        if (isset($this->parts[1])) {
+            $headers = $this->getPart('headers', $this->parts[1]);
+            return (isset($headers[$name])) ? $headers[$name] : false;
+        } else {
+            throw new \Exception(
+                'setPath() or setText() or setStream() must be called before retrieving email headers.'
+            );
+        }
+    }
+
+    /**
      * Retrieve a specific Email Header
      * @return String
      * @param $name String Header name
      */
     public function getHeader($name)
     {
-        if (isset($this->parts[1])) {
-            $headers = $this->getPart('headers', $this->parts[1]);
-            return (isset($headers[$name])) ? $this->decodeHeader($headers[$name]) : false;
-        } else {
-            throw new \Exception(
-                'setPath() or setText() or setStream() must be called before retrieving email headers.'
-            );
+        $rawHeader = $this->getRawHeader($name);
+        if($rawHeader === false) {
+            return false;
         }
+        return $this->decodeHeader($rawHeader);
     }
 
     /**


### PR DESCRIPTION
When the subject of an e-mail cannot be decoded by iconv(), the getHeader('subject') call generates iconv() warnings. It makes it impossible to retrieve the header contents (even without decoding). I added a getRawHeader() to make it possible to access raw headers.

Sample invalid subject (consists of two parts, but decodeHeader() currently doesn't handle that):

````=?GB2312?B?1rvSqsTjxNzP66Os1rvSqsTjz+vX9qOsv827p7K7ysfOyszio6zLq8+yyO28?= =?GB2312?B?/rDvxPq94r72o6GjoQ==?=````