### PR TITLE
Updating README & Removing global namespace option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ $htmlEmbedded = $Parser->getMessageBody('htmlEmbedded'); //HTML Body included da
 
 // and the attachments also
 $attach_dir = '/path/to/save/attachments/';
-$Parser->saveAttachments($attach_dir);
+// public url
+$url = 'http://my-domain.com/'.$attach_dir;
+$Parser->saveAttachments($attach_dir, $url);
 
 // loop the attachments
 $attachments = $Parser->getAttachments();

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -125,7 +125,7 @@ class Parser
      */
     public function setText($data)
     {
-        $this->resource = \mailparse_msg_create();
+        $this->resource = mailparse_msg_create();
         // does not parse incrementally, fast memory hog might explode
         mailparse_msg_parse($this->resource, $data);
         $this->data = $data;


### PR DESCRIPTION
Updating README documentation to include required parameter of $url in Parser saveAttachments function.

Removing global namespace from Parser.php as it wasn't consistent with the rest of the function calls & isn't needed.