### PR TITLE
Correct CID replacement

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -239,8 +239,8 @@ class Parser
             foreach ($attachments as $attachment) {
                 if ($attachment->getContentID() != '') {
                     $body = str_replace(
-                        'cid:'.$attachment->getContentID(),
-                        $this->getEmbeddedData($attachment->getContentID()),
+                        '"cid:'.$attachment->getContentID().'"',
+                        '"'.$this->getEmbeddedData($attachment->getContentID()).'"',
                         $body
                     );
                 }


### PR DESCRIPTION
if CID is generated like image-34-*, replacement will cause a problem
image-34-1
image-34-2
...
image-34-10
image-34-11

src for image-34-10 will be: {data}0