### PR TITLE
Make header retrieval case-insensitive

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -172,13 +172,14 @@ class Parser
     /**
      * Retrieve a specific Email Header, without charset conversion.
      *
-     * @param string $name Header name
+     * @param string $name Header name (case-insensitive)
      *
      * @return string
      * @throws Exception
      */
     public function getRawHeader($name)
     {
+        $name = strtolower($name);
         if (isset($this->parts[1])) {
             $headers = $this->getPart('headers', $this->parts[1]);
 
@@ -193,7 +194,7 @@ class Parser
     /**
      * Retrieve a specific Email Header
      *
-     * @param string $name Header name
+     * @param string $name Header name (case-insensitive)
      *
      * @return string
      */
@@ -372,7 +373,7 @@ class Parser
     /**
      * Return an array with the following keys display, address, is_group
      *
-     * @param string $name Header name
+     * @param string $name Header name (case-insensitive)
      *
      * @return array
      */

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1286,4 +1286,18 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             }
         }
     }
+
+    public function testHeaderRetrievalIsCaseInsensitive()
+    {
+        //Init
+        $file = __DIR__.'/mails/m0001';
+
+        //Load From Path
+        $Parser = new Parser();
+        $Parser->setPath($file);
+
+        $this->assertEquals($Parser->getRawHeader('From'), $Parser->getRawHeader('from'));
+        $this->assertEquals($Parser->getHeader('From'), $Parser->getHeader('from'));
+        $this->assertEquals($Parser->getAddresses('To'), $Parser->getAddresses('to'));
+    }
 }


### PR DESCRIPTION
At the moment, case folding is applied to header names rendering them exclusively in lower-case. This change updates the Parser->getRawHeader($name) function and related functions to always fold the header name to lower-case.

This prevents confusion when someone tries to match the header name exactly as it's stored in an RFC(2)822 file and matches the functionality offered by a lot of other libraries that deal with headers.

NB: Adding a test for this would be trivial, however, I was not sure how to kick them off myself. That would be a nice future addition to README.md :-)