### PR TITLE
Added option to include/exclude inline attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The php script must use the fourth method to work with this configuration.
 
 Feel free to contribute!
 
-	git clone https://github.com/php-mime-mail-parser/php-mime-mail-parser
+	git clone git clone https://github.com/php-mime-mail-parser/php-mime-mail-parser
 	cd php-mime-mail-parser
 	composer install
 	./vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -96,11 +96,12 @@ $stringHeaders = $Parser->getHeadersRaw();	// Get all headers as a string, no ch
 $arrayHeaders = $Parser->getHeaders();		// Get all headers as an array, with charset conversion
 
 // Pass in a writeable path to save attachments
-$attach_dir = '/path/to/save/attachments/';
-$Parser->saveAttachments($attach_dir);
+$attach_dir = '/path/to/save/attachments/'; 	// Be sure to include the trailing slash
+$include_inline = false 			// Optional argument to include inline attachments (default: false)
+$Parser->saveAttachments($attach_dir [,$include_inline]);
 
 // Get an array of Attachment items from $Parser
-$attachments = $Parser->getAttachments();
+$attachments = $Parser->getAttachments([$include_inline]);
 
 //  Loop through all the Attachments
 if (count($attachments) > 0) {

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $arrayHeaders = $Parser->getHeaders();		// Get all headers as an array, with cha
 
 // Pass in a writeable path to save attachments
 $attach_dir = '/path/to/save/attachments/'; 	// Be sure to include the trailing slash
-$include_inline = false 			// Optional argument to include inline attachments (default: false)
+$include_inline = true  			// Optional argument to include inline attachments (default: true)
 $Parser->saveAttachments($attach_dir [,$include_inline]);
 
 // Get an array of Attachment items from $Parser

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The php script must use the fourth method to work with this configuration.
 
 Feel free to contribute!
 
-	git clone git clone https://github.com/php-mime-mail-parser/php-mime-mail-parser
+	git clone https://github.com/php-mime-mail-parser/php-mime-mail-parser
 	cd php-mime-mail-parser
 	composer install
 	./vendor/bin/phpunit

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -403,6 +403,7 @@ class Parser
 
         foreach ($this->parts as $part) {
             $disposition = $this->getPart('content-disposition', $part);
+            $filename = 'noname';
 
             if (isset($part['disposition-filename'])) {
                 $filename = $this->decodeHeader($part['disposition-filename']);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -392,7 +392,7 @@ class Parser
      *
      * @return Attachment[]
      */
-    public function getAttachments($include_inline = false)
+    public function getAttachments($include_inline = true)
     {
         $attachments = [];
         if ($include_inline) {
@@ -456,7 +456,7 @@ class Parser
      * @return array Saved attachments paths
      * @throws Exception
      */
-    public function saveAttachments($attach_dir, $include_inline = false)
+    public function saveAttachments($attach_dir, $include_inline = true)
     {
         $attachments = $this->getAttachments($include_inline);
         if (empty($attachments)) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -392,16 +392,19 @@ class Parser
      *
      * @return Attachment[]
      */
-    public function getAttachments()
+    public function getAttachments($include_inline=false)
     {
         $attachments = [];
-        $dispositions = ['attachment', 'inline'];
+        if ($include_inline) {
+            $dispositions = ['attachment', 'inline'];
+        } else {
+            $dispositions = ['attachment'];
+        }
         $non_attachment_types = ['text/plain', 'text/html'];
         $nonameIter = 0;
 
         foreach ($this->parts as $part) {
             $disposition = $this->getPart('content-disposition', $part);
-            $filename = 'noname';
 
             if (isset($part['disposition-filename'])) {
                 $filename = $this->decodeHeader($part['disposition-filename']);
@@ -419,8 +422,8 @@ class Parser
                 $disposition = 'attachment';
             }
 
-            if (in_array($disposition, $dispositions) === true && isset($filename) === true) {
-                if ($filename == 'noname') {
+            if (in_array($disposition, $dispositions) === true) {
+                if (!isset($filename)) {
                     $nonameIter++;
                     $filename = 'noname'.$nonameIter;
                 }
@@ -453,9 +456,9 @@ class Parser
      * @return array Saved attachments paths
      * @throws Exception
      */
-    public function saveAttachments($attach_dir)
+    public function saveAttachments($attach_dir,$include_inline=false)
     {
-        $attachments = $this->getAttachments();
+        $attachments = $this->getAttachments($include_inline);
         if (empty($attachments)) {
             return false;
         }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -403,7 +403,6 @@ class Parser
 
         foreach ($this->parts as $part) {
             $disposition = $this->getPart('content-disposition', $part);
-            $filename = 'noname';
 
             if (isset($part['disposition-filename'])) {
                 $filename = $this->decodeHeader($part['disposition-filename']);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -395,16 +395,15 @@ class Parser
     public function getAttachments($include_inline = true)
     {
         $attachments = [];
-        if ($include_inline) {
-            $dispositions = ['attachment', 'inline'];
-        } else {
-            $dispositions = ['attachment'];
-        }
+        $dispositions = $include_inline ?
+            ['attachment', 'inline'] :
+            ['attachment'];
         $non_attachment_types = ['text/plain', 'text/html'];
         $nonameIter = 0;
 
         foreach ($this->parts as $part) {
             $disposition = $this->getPart('content-disposition', $part);
+            $filename = 'noname';
 
             if (isset($part['disposition-filename'])) {
                 $filename = $this->decodeHeader($part['disposition-filename']);
@@ -423,7 +422,7 @@ class Parser
             }
 
             if (in_array($disposition, $dispositions) === true) {
-                if (!isset($filename)) {
+                if ($filename=='noname') {
                     $nonameIter++;
                     $filename = 'noname'.$nonameIter;
                 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -392,7 +392,7 @@ class Parser
      *
      * @return Attachment[]
      */
-    public function getAttachments($include_inline=false)
+    public function getAttachments($include_inline = false)
     {
         $attachments = [];
         if ($include_inline) {
@@ -456,7 +456,7 @@ class Parser
      * @return array Saved attachments paths
      * @throws Exception
      */
-    public function saveAttachments($attach_dir,$include_inline=false)
+    public function saveAttachments($attach_dir, $include_inline = false)
     {
         $attachments = $this->getAttachments($include_inline);
         if (empty($attachments)) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -422,7 +422,7 @@ class Parser
             }
 
             if (in_array($disposition, $dispositions) === true) {
-                if ($filename=='noname') {
+                if ($filename == 'noname') {
                     $nonameIter++;
                     $filename = 'noname'.$nonameIter;
                 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -14,6 +14,61 @@ use PhpMimeMailParser\Exception;
 class ParserTest extends \PHPUnit_Framework_TestCase
 {
 
+    /**
+     * @dataProvider provideData
+     */
+    public function testInlineAttachmentsFalse(
+        $mid,
+        $subjectExpected,
+        $fromAddressesExpected,
+        $fromExpected,
+        $toAddressesExpected,
+        $toExpected,
+        $textExpected,
+        $htmlExpected,
+        $attachmentsExpected,
+        $countEmbeddedExpected
+    ) {
+        //Init
+        $file = __DIR__.'/mails/'.$mid;
+
+        //Load From Path
+        $Parser = new Parser();
+        $Parser->setPath($file);
+
+        // Remove inline attachments from array
+        $attachmentsExpected = array_filter($attachmentsExpected, function ($attachment) {
+            return ($attachment[5] != 'inline');
+        });
+
+        //Test Nb Attachments (ignoring inline attachments)
+        $attachments = $Parser->getAttachments(false);
+        $this->assertEquals(count($attachmentsExpected), count($attachments));
+        $iterAttachments = 0;
+
+        //Test Attachments
+        if (count($attachmentsExpected) > 0) {
+            foreach ($attachmentsExpected as $attachmentExpected) {
+                //Test Filename Attachment
+                $this->assertEquals($attachmentExpected[0], $attachments[$iterAttachments]->getFilename());
+
+                //Test ContentType Attachment
+                $this->assertEquals($attachmentExpected[4], $attachments[$iterAttachments]->getContentType());
+
+                //Test ContentDisposition Attachment
+                $this->assertEquals($attachmentExpected[5], $attachments[$iterAttachments]->getContentDisposition());
+
+                //Test md5 of Headers Attachment
+                $this->assertEquals(
+                    $attachmentExpected[6],
+                    md5(serialize($attachments[$iterAttachments]->getHeaders()))
+                );
+                
+                $iterAttachments++;
+            }
+        }
+    }
+
     public function testMultipleContentTransferEncodingHeader()
     {
         $file = __DIR__.'/mails/issue126';


### PR DESCRIPTION
Added an optional argument to getAttachments and saveAttachments to include inline attachments (defaults to false). Also update the README file accordingly. 