### PR TITLE
Fix handling of duplicate attachment filenames and offer strategies in ->saveAttachments()

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -466,8 +466,11 @@ class Parser
      * @return array Saved attachments paths
      * @throws Exception
      */
-    public function saveAttachments($attach_dir, $include_inline = true, $filenameStrategy = self::ATTACHMENT_DUPLICATE_SUFFIX)
-    {
+    public function saveAttachments(
+        $attach_dir,
+        $include_inline = true,
+        $filenameStrategy = self::ATTACHMENT_DUPLICATE_SUFFIX
+    ) {
         $attachments = $this->getAttachments($include_inline);
         if (empty($attachments)) {
             return false;

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -164,5 +164,43 @@ namespace PhpMimeMailParser {
 
             $Parser->saveAttachments($attach_dir, $attach_url);
         }
+
+        /**
+         * @expectedException        Exception
+         * @expectedExceptionMessage Could not create file for attachment: duplicate filename.
+         */
+        public function testSaveAttachmentsWithDuplicateNames()
+        {
+            $mid = 'm0026';
+            $file = __DIR__ . '/mails/' . $mid;
+            $attach_dir = __DIR__ . '/mails/attach_' . $mid . '/';
+
+            $Parser = new Parser();
+            $Parser->setText(file_get_contents($file));
+
+            try {
+                $Parser->saveAttachments($attach_dir, false, Parser::ATTACHMENT_DUPLICATE_THROW);
+            } catch (Exception $e) {
+                // Clean up attachments dir
+                unlink($attach_dir . 'ATT00001.txt');
+                rmdir($attach_dir);
+
+                throw $e;
+            }
+        }
+
+        /**
+         * @expectedException        Exception
+         * @expectedExceptionMessage Invalid filename strategy argument provided.
+         */
+        public function testSaveAttachmentsInvalidStrategy()
+        {
+            $file = __DIR__ . '/mails/m0026';
+
+            $Parser = new Parser();
+            $Parser->setText(file_get_contents($file));
+
+            $Parser->saveAttachments('dir', false, 'InvalidValue');
+        }
     }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -78,6 +78,44 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         
         $this->assertEquals("attach_01", $attachments[0]->getFilename());
     }
+
+    public function testAttachmentsWithDuplicatesSuffix()
+    {
+        $file = __DIR__ . '/mails/m0026';
+        $Parser = new Parser();
+        $Parser->setText(file_get_contents($file));
+
+        $attachDir = __DIR__ . '/mails/m0026_attachments/';
+        $Parser->saveAttachments($attachDir, false);
+
+        $attachmentFiles = glob($attachDir . 'ATT*');
+
+        // Clean up attachments dir
+        array_map('unlink', $attachmentFiles);
+        rmdir($attachDir);
+
+        // Default: generate filename suffix, so we should have two files
+        $this->assertEquals(2, count($attachmentFiles));
+    }
+
+    public function testAttachmentsWithDuplicatesRandom()
+    {
+        $file = __DIR__ . '/mails/m0026';
+        $Parser = new Parser();
+        $Parser->setText(file_get_contents($file));
+
+        $attachDir = __DIR__ . '/mails/m0026_attachments/';
+        $Parser->saveAttachments($attachDir, false, Parser::ATTACHMENT_RANDOM_FILENAME);
+
+        $attachmentFiles = glob($attachDir . '*');
+
+        // Clean up attachments dir
+        array_map('unlink', $attachmentFiles);
+        rmdir($attachDir);
+
+        // Default: generate filename suffix, so we should have two files
+        $this->assertEquals(2, count($attachmentFiles));
+    }
     
     public function testMultipleContentTransferEncodingHeader()
     {

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -113,7 +113,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         array_map('unlink', $attachmentFiles);
         rmdir($attachDir);
 
-        // Default: generate filename suffix, so we should have two files
+        // Default: generate random filename, so we should have two files
         $this->assertEquals(2, count($attachmentFiles));
     }
     

--- a/tests/mails/m0026
+++ b/tests/mails/m0026
@@ -1,0 +1,45 @@
+Return-Path: <name@company.com>
+Delivered-To: name@company2.com
+From: <name@company.com>
+To: "name@company2.com" <name@company2.com>
+Subject: [Korea] Name
+Date: Mon, 20 Oct 2014 07:15:27 +0000
+Message-ID: <7B2F0B04-7286-488B-990B-D2EE3759554D@company.com>
+Accept-Language: ko-KR, en-US
+Content-Language: ko-KR
+X-MS-Has-Attach: yes
+X-MS-TNEF-Correlator:
+Content-Type: multipart/mixed;
+    boundary="_003_7B2F0B047286488B990BD2EE3759554Dcompanykoreacokr_"
+MIME-Version: 1.0
+
+--_003_7B2F0B047286488B990BD2EE3759554Dcompanykoreacokr_
+Content-Type: text/plain; charset="ks_c_5601-1987"
+Content-ID: <E31E4DF95743304BB1C77F55A2E0F9B7@company.com>
+Content-Transfer-Encoding: base64
+
+TXkgdHJhdmVsaW5nIGNvbXBhbmlvbnMhDQpNeSBmcmllbmQsIExlIFBsaWFnZSEgDQoNCg==
+
+--_003_7B2F0B047286488B990BD2EE3759554Dcompanykoreacokr_
+Content-Type: text/plain; name="ATT00001.txt"
+Content-Description: ATT00001.txt
+Content-Disposition: attachment; filename="ATT00001.txt"; size=25;
+    creation-date="Mon, 20 Oct 2014 07:15:27 GMT";
+    modification-date="Mon, 20 Oct 2014 07:15:27 GMT"
+Content-ID: <57BAB4E7BA79CB40B41CE0993FA444D4@company.com>
+Content-Transfer-Encoding: base64
+
+DQoNCg0Kc2VudCBmcm9tIG15IGlQaG9uZQ==
+
+--_003_7B2F0B047286488B990BD2EE3759554Dcompanykoreacokr_
+Content-Type: text/plain; name="ATT00001.txt"
+Content-Description: ATT00001.txt
+Content-Disposition: attachment; filename="ATT00001.txt"; size=25;
+    creation-date="Mon, 20 Oct 2014 07:15:27 GMT";
+    modification-date="Mon, 20 Oct 2014 07:15:27 GMT"
+Content-ID: <57BAB4E7BA79CB40B41CE0993FA444D5@company.com>
+Content-Transfer-Encoding: base64
+
+DQoNCg0Kc2VudCBmcm9tIG15IGlQaG9uZQ==
+
+--_003_7B2F0B047286488B990BD2EE3759554Dcompanykoreacokr_--


### PR DESCRIPTION
This is an alternative solution to PR #63 where we now prevent filename collisions by default.

* Public API for ->saveAttachments() is expanded with a filename strategy argument
* Makes use of tempnam() to generate unique filenames whenever necessary
* Tests added to expose duplicate filename bug and test new filename strategy functionality