### PR TITLE
Fix for AttachementFilename when only content-name is used

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -420,6 +420,8 @@ class Parser
                 // if we have no disposition but we have a content-name, it's a valid attachment.
                 // we simulate the presence of an attachment disposition with a disposition filename
                 $filename = $this->decodeHeader($part['content-name']);
+                // Escape all potentially unsafe characters from the filename
+                $filename = preg_replace('((^\.)|\/|(\.$))', '_', $filename);
                 $disposition = 'attachment';
             } elseif (in_array($part['content-type'], $non_attachment_types, true)
                 && $disposition !== 'attachment') {

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -71,7 +71,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
     public function testIlligalAttachementFilename()
     {
-        $file = __DIR__ . '/mails/issue133';
+        $file = __DIR__ . '/mails/m0027';
         $Parser = new Parser();
         $Parser->setText(file_get_contents($file));
         $attachments = $Parser->getAttachments(false);

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -76,7 +76,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $Parser->setText(file_get_contents($file));
         $attachments = $Parser->getAttachments(false);
         
-        $this->assertEquals("attach_01", $attachments[0]->getFilename());
+        $this->assertEquals("1234_1234.txt", $attachments[0]->getFilename());
     }
 
     public function testAttachmentsWithDuplicatesSuffix()

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -69,13 +69,23 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testIlligalAttachementFilename()
+    public function testIlligalAttachmentFilenameForDispositionFilename()
+    {
+        $file = __DIR__ . '/mails/issue133';
+        $Parser = new Parser();
+        $Parser->setText(file_get_contents($file));
+        $attachments = $Parser->getAttachments(false);
+        
+        $this->assertEquals("attach_01", $attachments[0]->getFilename());
+    }
+
+    public function testIlligalAttachmentFilenameForContentName()
     {
         $file = __DIR__ . '/mails/m0027';
         $Parser = new Parser();
         $Parser->setText(file_get_contents($file));
         $attachments = $Parser->getAttachments(false);
-        
+
         $this->assertEquals("1234_.._.._1234.txt", $attachments[0]->getFilename());
     }
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -76,7 +76,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $Parser->setText(file_get_contents($file));
         $attachments = $Parser->getAttachments(false);
         
-        $this->assertEquals("1234_1234.txt", $attachments[0]->getFilename());
+        $this->assertEquals("1234_.._.._1234.txt", $attachments[0]->getFilename());
     }
 
     public function testAttachmentsWithDuplicatesSuffix()

--- a/tests/mails/m0027
+++ b/tests/mails/m0027
@@ -1,0 +1,7 @@
+Subject: 1234 / 1234
+To: <name@company.com>
+MIME-Version: 1.0
+Content-Type: application/txt;
+ name="1234/../../1234.txt"
+Content-Transfer-Encoding: base64
+Content-Description: 1234 / 1234


### PR DESCRIPTION
Added m0027 and changed testIlligalAttachementFilename() to use m0027. This issue  is related to #133 