### PR TITLE
Fixes #158 : to not include parts from attachments in getMessageBody()

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -308,6 +308,37 @@ class Parser
     }
 
     /**
+     * Checks whether a given part ID is a child of another part
+     * eg. an RFC822 attachment may have one or more text parts
+     *
+     * @param string $partId
+     * @param string $parentPartId
+     * @return bool
+     */
+    protected function partIdIsChildOfPart($partId, $parentPartId)
+    {
+        return substr($partId, 0, strlen($parentPartId)) == $parentPartId;
+    }
+
+    /**
+     * Whether the given part ID is a child of any attachment part in the message.
+     *
+     * @param string $checkPartId
+     * @return bool
+     */
+    protected function partIdIsChildOfAnAttachment($checkPartId)
+    {
+        foreach ($this->parts as $partId => $part) {
+            if ($this->getPart('content-disposition', $part) == 'attachment') {
+                if ($this->partIdIsChildOfPart($checkPartId, $partId)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Returns the email message body in the specified format
      *
      * @param string $type text, html or htmlEmbedded
@@ -323,10 +354,12 @@ class Parser
         'html'         => 'text/html',
         'htmlEmbedded' => 'text/html',
         ];
+
         if (in_array($type, array_keys($mime_types))) {
-            foreach ($this->parts as $part) {
+            foreach ($this->parts as $partId => $part) {
                 if ($this->getPart('content-type', $part) == $mime_types[$type]
                     && $this->getPart('content-disposition', $part) != 'attachment'
+                    && !$this->partIdIsChildOfAnAttachment($partId)
                     ) {
                     $headers = $this->getPart('headers', $part);
                     $encodingType = array_key_exists('content-transfer-encoding', $headers) ?

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1578,4 +1578,69 @@ aXBpdC4K'
             $i++;
         }
     }
+
+    /**
+     * @dataProvider providerRFC822AttachmentsWithDifferentTextTypes
+     *
+     * @param string $file Mail file path to parse
+     * @param string $getType The type to give to getMessageBody
+     * @param string $expected
+     */
+    public function testRFC822AttachmentPartsShouldNotBeIncludedInGetMessageBody($file, $getType, $expected)
+    {
+        $Parser = new Parser();
+        $Parser->setPath($file);
+        $this->assertEquals($expected, $Parser->getMessageBody($getType));
+    }
+
+    public function providerRFC822AttachmentsWithDifferentTextTypes()
+    {
+        return [
+            'HTML-only message, with text-only RFC822 attachment, message should have empty text body' => [
+                __DIR__.'/mails/issue158a',
+                'text',
+                ''
+            ],
+            'HTML-only message, with text-only RFC822 attachment, message should have HTML body' => [
+                __DIR__.'/mails/issue158a',
+                'html',
+                "<html><body><div style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt; color: #000000\"><div>An RFC 822 forward with a <em>HTML</em> body where the <strong>original</strong> message was in <span data-mce-style=\"text-decoration: underline;\" style=\"text-decoration: underline;\">plain text</span>.<br></div><div><br data-mce-bogus=\"1\"></div><div>Filler filler filler filler filler filler filler filler</div><div> filler filler filler filler filler filler filler</div><div> filler filler filler filler filler filler<br></div><div> filler filler filler filler filler</div><div> filler filler filler filler</div><div> filler filler filler</div><div> filler filler</div><div> filler.</div></div></body></html>\n"
+            ],
+            'Text-only message, with HTML-only RFC822 attachment, message should have empty HTML body' => [
+                __DIR__.'/mails/issue158b',
+                'html',
+                ''
+            ],
+            'Text-only message, with HTML-only RFC822 attachment, message should have text body' => [
+                __DIR__.'/mails/issue158b',
+                'text',
+                "A text/plain response to an REC822 message, with content filler to get it past the
+200 character lower-limit in order to avoid preferring future HTML versions of the
+body... filler filler filler filler filler filler filler filler filler.\n"
+            ],
+            'Text-only message, with text-only RFC822 attachment, should have text body but not include attachment part' => [
+                __DIR__.'/mails/issue158c',
+                'text',
+                "An RFC822 forward of a PLAIN TEXT message with a plain-text body.\n"
+            ],
+            'Text-only message, with a text-only RFC822 attachment, message should have an empty HTML body' => [
+                __DIR__.'/mails/issue158c',
+                'html',
+                ''
+            ],
+            'Multipart email with both text and html body, with RFC822 attachment also with a text and html body' => [
+                __DIR__.'/mails/issue158d',
+                'text',
+                "This is the forward email send both emails will have both text and html variances available\n"
+            ],
+            'Multipart with both text and html body, RFC822 attachment also with text and html' => [
+                __DIR__.'/mails/issue158d',
+                'html',
+                '<html><body><div style="font-family: arial, helvetica, sans-serif; font-size: 12pt; color: #000000"><div>This is the forward email send both emails will have both text and html variances available &nbsp;</div></div></body></html>'
+            ],
+        ];
+    }
+
+
+
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1637,7 +1637,9 @@ body... filler filler filler filler filler filler filler filler filler.\n"
             'Multipart with both text and html body, RFC822 attachment also with text and html' => [
                 __DIR__.'/mails/issue158d',
                 'html',
-                '<html><body><div style="font-family: arial, helvetica, sans-serif; font-size: 12pt; color: #000000"><div>This is the forward email send both emails will have both text and html variances available &nbsp;</div></div></body></html>'
+                '<html><body><div>This is the forward email send both
+emails will have both text and html
+variances available &nbsp;</div></body></html>'
             ],
         ];
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1604,13 +1604,7 @@ aXBpdC4K'
             'HTML-only message, with text-only RFC822 attachment, message should have HTML body' => [
                 __DIR__.'/mails/issue158a',
                 'html',
-                "<html><body><div style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt; color: #000000\"><div>
-An RFC 822 forward with a <em>HTML</em> body where the <strong>original</strong> message was in 
-<span data-mce-style=\"text-decoration: underline;\" style=\"text-decoration: underline;\">plain text</span>.
-<br></div><div><br data-mce-bogus=\"1\"></div><div>Filler filler filler filler filler filler filler filler</div>
-<div> filler filler filler filler filler filler filler</div><div> filler filler filler filler filler filler<br>
-</div><div> filler filler filler filler filler</div><div> filler filler filler filler</div><div> filler filler filler
-</div><div> filler filler</div><div> filler.</div></div></body></html>\n"
+                "<html><body>An RFC 822 forward with a <em>HTML</em> body</body></html>\n"
             ],
             'Text-only message, with HTML-only RFC822 attachment, message should have empty HTML body' => [
                 __DIR__.'/mails/issue158b',

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1640,7 +1640,4 @@ body... filler filler filler filler filler filler filler filler filler.\n"
             ],
         ];
     }
-
-
-
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1618,7 +1618,8 @@ aXBpdC4K'
 200 character lower-limit in order to avoid preferring future HTML versions of the
 body... filler filler filler filler filler filler filler filler filler.\n"
             ],
-            'Text-only message, with text-only RFC822 attachment, should have text body but not include attachment part' => [
+            'Text-only message, with text-only RFC822 attachment, 
+            should have text body but not include attachment part' => [
                 __DIR__.'/mails/issue158c',
                 'text',
                 "An RFC822 forward of a PLAIN TEXT message with a plain-text body.\n"

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1604,7 +1604,13 @@ aXBpdC4K'
             'HTML-only message, with text-only RFC822 attachment, message should have HTML body' => [
                 __DIR__.'/mails/issue158a',
                 'html',
-                "<html><body><div style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt; color: #000000\"><div>An RFC 822 forward with a <em>HTML</em> body where the <strong>original</strong> message was in <span data-mce-style=\"text-decoration: underline;\" style=\"text-decoration: underline;\">plain text</span>.<br></div><div><br data-mce-bogus=\"1\"></div><div>Filler filler filler filler filler filler filler filler</div><div> filler filler filler filler filler filler filler</div><div> filler filler filler filler filler filler<br></div><div> filler filler filler filler filler</div><div> filler filler filler filler</div><div> filler filler filler</div><div> filler filler</div><div> filler.</div></div></body></html>\n"
+                "<html><body><div style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt; color: #000000\"><div>
+An RFC 822 forward with a <em>HTML</em> body where the <strong>original</strong> message was in 
+<span data-mce-style=\"text-decoration: underline;\" style=\"text-decoration: underline;\">plain text</span>.
+<br></div><div><br data-mce-bogus=\"1\"></div><div>Filler filler filler filler filler filler filler filler</div>
+<div> filler filler filler filler filler filler filler</div><div> filler filler filler filler filler filler<br>
+</div><div> filler filler filler filler filler</div><div> filler filler filler filler</div><div> filler filler filler
+</div><div> filler filler</div><div> filler.</div></div></body></html>\n"
             ],
             'Text-only message, with HTML-only RFC822 attachment, message should have empty HTML body' => [
                 __DIR__.'/mails/issue158b',

--- a/tests/mails/issue158a
+++ b/tests/mails/issue158a
@@ -16,7 +16,13 @@ Thread-Index: BsIxD6EDQhVNqaTfcPN/d36x7UYGq6dRLyIX
 Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: 7bit
 
-<html><body><div style="font-family: arial, helvetica, sans-serif; font-size: 12pt; color: #000000"><div>An RFC 822 forward with a <em>HTML</em> body where the <strong>original</strong> message was in <span data-mce-style="text-decoration: underline;" style="text-decoration: underline;">plain text</span>.<br></div><div><br data-mce-bogus="1"></div><div>Filler filler filler filler filler filler filler filler</div><div> filler filler filler filler filler filler filler</div><div> filler filler filler filler filler filler<br></div><div> filler filler filler filler filler</div><div> filler filler filler filler</div><div> filler filler filler</div><div> filler filler</div><div> filler.</div></div></body></html>
+<html><body><div style="font-family: arial, helvetica, sans-serif; font-size: 12pt; color: #000000"><div>
+An RFC 822 forward with a <em>HTML</em> body where the <strong>original</strong> message was in 
+<span data-mce-style="text-decoration: underline;" style="text-decoration: underline;">plain text</span>.
+<br></div><div><br data-mce-bogus="1"></div><div>Filler filler filler filler filler filler filler filler</div>
+<div> filler filler filler filler filler filler filler</div><div> filler filler filler filler filler filler<br>
+</div><div> filler filler filler filler filler</div><div> filler filler filler filler</div><div> filler filler filler
+</div><div> filler filler</div><div> filler.</div></div></body></html>
 
 ------=_Part_378129_257370687.1488812211065
 Content-Type: message/rfc822

--- a/tests/mails/issue158a
+++ b/tests/mails/issue158a
@@ -1,0 +1,68 @@
+Date: Mon, 6 Mar 2017 14:56:51 +0000 (GMT)
+From: Example Name <example@example.com>
+To: example@example.co.uk
+Message-ID: <445158045.378131.1488812211066.JavaMail.zimbra@zedcore.com>
+In-Reply-To: <649983063.377570.1488812041831.JavaMail.zimbra@zedcore.com>
+References: <649983063.377570.1488812041831.JavaMail.zimbra@zedcore.com>
+Subject: Fwd: Test 5
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+	boundary="----=_Part_378129_257370687.1488812211065"
+X-Mailer: Zimbra 8.6.0_GA_1200 (ZimbraWebClient - FF45 (Linux)/8.6.0_GA_1200)
+Thread-Topic: Test 5
+Thread-Index: BsIxD6EDQhVNqaTfcPN/d36x7UYGq6dRLyIX
+
+------=_Part_378129_257370687.1488812211065
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html><body><div style="font-family: arial, helvetica, sans-serif; font-size: 12pt; color: #000000"><div>An RFC 822 forward with a <em>HTML</em> body where the <strong>original</strong> message was in <span data-mce-style="text-decoration: underline;" style="text-decoration: underline;">plain text</span>.<br></div><div><br data-mce-bogus="1"></div><div>Filler filler filler filler filler filler filler filler</div><div> filler filler filler filler filler filler filler</div><div> filler filler filler filler filler filler<br></div><div> filler filler filler filler filler</div><div> filler filler filler filler</div><div> filler filler filler</div><div> filler filler</div><div> filler.</div></div></body></html>
+
+------=_Part_378129_257370687.1488812211065
+Content-Type: message/rfc822
+Content-Disposition: attachment
+
+Return-Path: example@example.com
+Received: from fermat.axiomtech.co.uk (LHLO fermat.axiomtech.co.uk)
+ (89.145.71.216) by fermat.axiomtech.co.uk with LMTP; Mon, 6 Mar 2017
+ 14:54:02 +0000 (GMT)
+Received: from localhost (localhost.localdomain [127.0.0.1])
+	by fermat.axiomtech.co.uk (Postfix) with ESMTP id 174DF1C407FD
+	for <example@example.com>; Mon,  6 Mar 2017 14:54:02 +0000 (GMT)
+X-Spam-Flag: NO
+X-Spam-Score: -2.9
+X-Spam-Level:
+X-Spam-Status: No, score=-2.9 tagged_above=-10 required=6.6
+	tests=[ALL_TRUSTED=-1, BAYES_00=-1.9] autolearn=ham autolearn_force=no
+Received: from fermat.axiomtech.co.uk ([127.0.0.1])
+	by localhost (fermat.axiomtech.co.uk [127.0.0.1]) (amavisd-new, port 10032)
+	with ESMTP id G83UfQTDA5rx for <example@example.com>;
+	Mon,  6 Mar 2017 14:54:01 +0000 (GMT)
+Received: from localhost (localhost.localdomain [127.0.0.1])
+	by fermat.axiomtech.co.uk (Postfix) with ESMTP id DEF301C40805
+	for <example@example.com>; Mon,  6 Mar 2017 14:54:01 +0000 (GMT)
+X-Virus-Scanned: amavisd-new at fermat.axiomtech.co.uk
+Received: from fermat.axiomtech.co.uk ([127.0.0.1])
+	by localhost (fermat.axiomtech.co.uk [127.0.0.1]) (amavisd-new, port 10026)
+	with ESMTP id g5r-rGDF7iTG for <example@example.com>;
+	Mon,  6 Mar 2017 14:54:01 +0000 (GMT)
+Received: from fermat.axiomtech.co.uk (fermat.axiomtech.co.uk [89.145.71.216])
+	by fermat.axiomtech.co.uk (Postfix) with ESMTP id CD9B21C407FD
+	for <example@example.co.uk>; Mon,  6 Mar 2017 14:54:01 +0000 (GMT)
+Date: Mon, 6 Mar 2017 14:54:01 +0000 (GMT)
+From: Example Name <example@example.com>
+To: example@example.co.uk
+Message-ID: <649983063.377570.1488812041831.JavaMail.zimbra@example.com>
+Subject: Test 5
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+X-Mailer: Zimbra 8.6.0_GA_1200 (ZimbraWebClient - FF45 (Linux)/8.6.0_GA_1200)
+Thread-Topic: Test 5
+Thread-Index: BsIxD6EDQhVNqaTfcPN/d36x7UYGqw==
+
+An original PLAIN TEXT message body, with content filler to get it past the
+200 character lower-limit in order to avoid preferring future HTML versions of the
+body... filler filler filler filler filler filler filler filler filler.
+
+------=_Part_378129_257370687.1488812211065--

--- a/tests/mails/issue158a
+++ b/tests/mails/issue158a
@@ -16,13 +16,7 @@ Thread-Index: BsIxD6EDQhVNqaTfcPN/d36x7UYGq6dRLyIX
 Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: 7bit
 
-<html><body><div style="font-family: arial, helvetica, sans-serif; font-size: 12pt; color: #000000"><div>
-An RFC 822 forward with a <em>HTML</em> body where the <strong>original</strong> message was in 
-<span data-mce-style="text-decoration: underline;" style="text-decoration: underline;">plain text</span>.
-<br></div><div><br data-mce-bogus="1"></div><div>Filler filler filler filler filler filler filler filler</div>
-<div> filler filler filler filler filler filler filler</div><div> filler filler filler filler filler filler<br>
-</div><div> filler filler filler filler filler</div><div> filler filler filler filler</div><div> filler filler filler
-</div><div> filler filler</div><div> filler.</div></div></body></html>
+<html><body>An RFC 822 forward with a <em>HTML</em> body</body></html>
 
 ------=_Part_378129_257370687.1488812211065
 Content-Type: message/rfc822

--- a/tests/mails/issue158b
+++ b/tests/mails/issue158b
@@ -1,0 +1,67 @@
+Date: Mon, 6 Mar 2017 14:56:51 +0000 (GMT)
+From: Example Name <example@example.com>
+To: example@example.co.uk
+Message-ID: <445158045.378131.1488812211066.JavaMail.zimbra@zedcore.com>
+In-Reply-To: <649983063.377570.1488812041831.JavaMail.zimbra@zedcore.com>
+References: <649983063.377570.1488812041831.JavaMail.zimbra@zedcore.com>
+Subject: Fwd: Test 5
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+	boundary="----=_Part_378129_257370687.1488812211065"
+X-Mailer: Zimbra 8.6.0_GA_1200 (ZimbraWebClient - FF45 (Linux)/8.6.0_GA_1200)
+Thread-Topic: Test 5
+Thread-Index: BsIxD6EDQhVNqaTfcPN/d36x7UYGq6dRLyIX
+
+------=_Part_378129_257370687.1488812211065
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+A text/plain response to an REC822 message, with content filler to get it past the
+200 character lower-limit in order to avoid preferring future HTML versions of the
+body... filler filler filler filler filler filler filler filler filler.
+
+------=_Part_378129_257370687.1488812211065
+Content-Type: message/rfc822
+Content-Disposition: attachment
+
+Return-Path: example@example.com
+Received: from fermat.axiomtech.co.uk (LHLO fermat.axiomtech.co.uk)
+ (89.145.71.216) by fermat.axiomtech.co.uk with LMTP; Mon, 6 Mar 2017
+ 14:54:02 +0000 (GMT)
+Received: from localhost (localhost.localdomain [127.0.0.1])
+	by fermat.axiomtech.co.uk (Postfix) with ESMTP id 174DF1C407FD
+	for <example@example.com>; Mon,  6 Mar 2017 14:54:02 +0000 (GMT)
+X-Spam-Flag: NO
+X-Spam-Score: -2.9
+X-Spam-Level:
+X-Spam-Status: No, score=-2.9 tagged_above=-10 required=6.6
+	tests=[ALL_TRUSTED=-1, BAYES_00=-1.9] autolearn=ham autolearn_force=no
+Received: from fermat.axiomtech.co.uk ([127.0.0.1])
+	by localhost (fermat.axiomtech.co.uk [127.0.0.1]) (amavisd-new, port 10032)
+	with ESMTP id G83UfQTDA5rx for <example@example.com>;
+	Mon,  6 Mar 2017 14:54:01 +0000 (GMT)
+Received: from localhost (localhost.localdomain [127.0.0.1])
+	by fermat.axiomtech.co.uk (Postfix) with ESMTP id DEF301C40805
+	for <example@example.com>; Mon,  6 Mar 2017 14:54:01 +0000 (GMT)
+X-Virus-Scanned: amavisd-new at fermat.axiomtech.co.uk
+Received: from fermat.axiomtech.co.uk ([127.0.0.1])
+	by localhost (fermat.axiomtech.co.uk [127.0.0.1]) (amavisd-new, port 10026)
+	with ESMTP id g5r-rGDF7iTG for <example@example.com>;
+	Mon,  6 Mar 2017 14:54:01 +0000 (GMT)
+Received: from fermat.axiomtech.co.uk (fermat.axiomtech.co.uk [89.145.71.216])
+	by fermat.axiomtech.co.uk (Postfix) with ESMTP id CD9B21C407FD
+	for <example@example.co.uk>; Mon,  6 Mar 2017 14:54:01 +0000 (GMT)
+Date: Mon, 6 Mar 2017 14:54:01 +0000 (GMT)
+From: Example Name <example@example.com>
+To: example@example.co.uk
+Message-ID: <649983063.377570.1488812041831.JavaMail.zimbra@example.com>
+Subject: Test 5
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+X-Mailer: Zimbra 8.6.0_GA_1200 (ZimbraWebClient - FF45 (Linux)/8.6.0_GA_1200)
+Thread-Topic: Test 5
+Thread-Index: BsIxD6EDQhVNqaTfcPN/d36x7UYGqw==
+
+<html><body><div style="font-family: arial, helvetica, sans-serif; font-size: 12pt; color: #000000"><div>A text/<em>HTML</em> body this is the <strong>original</strong> message <span data-mce-style="text-decoration: underline;" style="text-decoration: underline;">sent</span>.<br></div><div><br data-mce-bogus="1"></div><div>Filler filler filler filler filler filler filler filler</div><div> filler filler filler filler filler filler filler</div><div> filler filler filler filler filler filler<br></div><div> filler filler filler filler filler</div><div> filler filler filler filler</div><div> filler filler filler</div><div> filler filler</div><div> filler.</div></div></body></html>
+------=_Part_378129_257370687.1488812211065--

--- a/tests/mails/issue158c
+++ b/tests/mails/issue158c
@@ -1,0 +1,68 @@
+Date: Mon, 6 Mar 2017 14:56:51 +0000 (GMT)
+From: Example Name <example@example.com>
+To: example@example.co.uk
+Message-ID: <445158045.378131.1488812211066.JavaMail.zimbra@zedcore.com>
+In-Reply-To: <649983063.377570.1488812041831.JavaMail.zimbra@zedcore.com>
+References: <649983063.377570.1488812041831.JavaMail.zimbra@zedcore.com>
+Subject: Fwd: Test 5
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+	boundary="----=_Part_378129_257370687.1488812211065"
+X-Mailer: Zimbra 8.6.0_GA_1200 (ZimbraWebClient - FF45 (Linux)/8.6.0_GA_1200)
+Thread-Topic: Test 5
+Thread-Index: BsIxD6EDQhVNqaTfcPN/d36x7UYGq6dRLyIX
+
+------=_Part_378129_257370687.1488812211065
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+An RFC822 forward of a PLAIN TEXT message with a plain-text body.
+
+------=_Part_378129_257370687.1488812211065
+Content-Type: message/rfc822
+Content-Disposition: attachment
+
+Return-Path: example@example.com
+Received: from fermat.axiomtech.co.uk (LHLO fermat.axiomtech.co.uk)
+ (89.145.71.216) by fermat.axiomtech.co.uk with LMTP; Mon, 6 Mar 2017
+ 14:54:02 +0000 (GMT)
+Received: from localhost (localhost.localdomain [127.0.0.1])
+	by fermat.axiomtech.co.uk (Postfix) with ESMTP id 174DF1C407FD
+	for <example@example.com>; Mon,  6 Mar 2017 14:54:02 +0000 (GMT)
+X-Spam-Flag: NO
+X-Spam-Score: -2.9
+X-Spam-Level:
+X-Spam-Status: No, score=-2.9 tagged_above=-10 required=6.6
+	tests=[ALL_TRUSTED=-1, BAYES_00=-1.9] autolearn=ham autolearn_force=no
+Received: from fermat.axiomtech.co.uk ([127.0.0.1])
+	by localhost (fermat.axiomtech.co.uk [127.0.0.1]) (amavisd-new, port 10032)
+	with ESMTP id G83UfQTDA5rx for <example@example.com>;
+	Mon,  6 Mar 2017 14:54:01 +0000 (GMT)
+Received: from localhost (localhost.localdomain [127.0.0.1])
+	by fermat.axiomtech.co.uk (Postfix) with ESMTP id DEF301C40805
+	for <example@example.com>; Mon,  6 Mar 2017 14:54:01 +0000 (GMT)
+X-Virus-Scanned: amavisd-new at fermat.axiomtech.co.uk
+Received: from fermat.axiomtech.co.uk ([127.0.0.1])
+	by localhost (fermat.axiomtech.co.uk [127.0.0.1]) (amavisd-new, port 10026)
+	with ESMTP id g5r-rGDF7iTG for <example@example.com>;
+	Mon,  6 Mar 2017 14:54:01 +0000 (GMT)
+Received: from fermat.axiomtech.co.uk (fermat.axiomtech.co.uk [89.145.71.216])
+	by fermat.axiomtech.co.uk (Postfix) with ESMTP id CD9B21C407FD
+	for <example@example.co.uk>; Mon,  6 Mar 2017 14:54:01 +0000 (GMT)
+Date: Mon, 6 Mar 2017 14:54:01 +0000 (GMT)
+From: Example Name <example@example.com>
+To: example@example.co.uk
+Message-ID: <649983063.377570.1488812041831.JavaMail.zimbra@example.com>
+Subject: Test 5
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+X-Mailer: Zimbra 8.6.0_GA_1200 (ZimbraWebClient - FF45 (Linux)/8.6.0_GA_1200)
+Thread-Topic: Test 5
+Thread-Index: BsIxD6EDQhVNqaTfcPN/d36x7UYGqw==
+
+An original PLAIN TEXT message body, with content filler to get it past the
+200 character lower-limit in order to avoid preferring future HTML versions of the
+body... filler filler filler filler filler filler filler filler filler.
+
+------=_Part_378129_257370687.1488812211065--

--- a/tests/mails/issue158d
+++ b/tests/mails/issue158d
@@ -26,7 +26,9 @@ This is the forward email send both emails will have both text and html variance
 Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: 7bit
 
-<html><body><div style="font-family: arial, helvetica, sans-serif; font-size: 12pt; color: #000000"><div>This is the forward email send both emails will have both text and html variances available &nbsp;</div></div></body></html>
+<html><body><div>This is the forward email send both
+emails will have both text and html
+variances available &nbsp;</div></body></html>
 ------=_Part_226414_202573469.1505469984034--
 
 ------=_Part_226413_1101864383.1505469984034

--- a/tests/mails/issue158d
+++ b/tests/mails/issue158d
@@ -1,0 +1,76 @@
+Date: Fri, 15 Sep 2017 11:06:24 +0100 (BST)
+From: Daniel Haswell <dhaswell@zedcore.com>
+To: Daniel Haswell <dhaswell@zedcore.com>
+Message-ID: <1589397930.226415.1505469984035.JavaMail.zimbra@zedcore.com>
+In-Reply-To: <904828280.225702.1505469919264.JavaMail.zimbra@zedcore.com>
+References: <904828280.225702.1505469919264.JavaMail.zimbra@zedcore.com>
+Subject: Fwd: Test 6
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+	boundary="----=_Part_226413_1101864383.1505469984034"
+X-Mailer: Zimbra 8.6.0_GA_1200 (ZimbraWebClient - GC57 (Linux)/8.6.0_GA_1200)
+Thread-Topic: Test 6
+Thread-Index: qORzv4EJUFSMCg6QwqdG3te7SEGc45AvczMT
+
+------=_Part_226413_1101864383.1505469984034
+Content-Type: multipart/alternative;
+	boundary="----=_Part_226414_202573469.1505469984034"
+
+------=_Part_226414_202573469.1505469984034
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+This is the forward email send both emails will have both text and html variances available
+
+------=_Part_226414_202573469.1505469984034
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html><body><div style="font-family: arial, helvetica, sans-serif; font-size: 12pt; color: #000000"><div>This is the forward email send both emails will have both text and html variances available &nbsp;</div></div></body></html>
+------=_Part_226414_202573469.1505469984034--
+
+------=_Part_226413_1101864383.1505469984034
+Content-Type: message/rfc822
+Content-Disposition: attachment
+
+Date: Fri, 15 Sep 2017 11:05:19 +0100 (BST)
+From: Daniel Haswell <dhaswell@zedcore.com>
+To: Daniel Haswell <dhaswell@zedcore.com>
+Message-ID: <904828280.225702.1505469919264.JavaMail.zimbra@zedcore.com>
+Subject: Test 6
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+	boundary="----=_Part_225701_622005900.1505469919263"
+X-Mailer: Zimbra 8.6.0_GA_1200 (ZimbraWebClient - GC57 (Linux)/8.6.0_GA_1200)
+Thread-Topic: Test 6
+Thread-Index: qORzv4EJUFSMCg6QwqdG3te7SEGc4w==
+
+------=_Part_225701_622005900.1505469919263
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+This is the original email sent it will include this and a html variant
+
+------=_Part_225701_622005900.1505469919263
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+<html><body><div style=3D"font-family: arial, helvetica, sans-serif; font-s=
+ize: 12pt; color: #000000"><div><span style=3D"color: #333333; font-family:=
+ monospace; font-size: 14.16px; font-style: normal; font-variant-ligatures:=
+ normal; font-variant-caps: normal; font-weight: normal; letter-spacing: no=
+rmal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none=
+; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-wi=
+dth: 0px; background-color: #fdfcfa; text-decoration-style: initial; text-d=
+ecoration-color: initial; display: inline !important; float: none;" data-mc=
+e-style=3D"color: #333333; font-family: monospace; font-size: 14.16px; font=
+-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; =
+font-weight: normal; letter-spacing: normal; orphans: 2; text-align: start;=
+ text-indent: 0px; text-transform: none; white-space: normal; widows: 2; wo=
+rd-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: #fdfcfa;=
+ text-decoration-style: initial; text-decoration-color: initial; display: i=
+nline !important; float: none;">This is the original email sent it will inc=
+lude this and a html variant</span></div></div></body></html>
+------=_Part_225701_622005900.1505469919263--
+
+------=_Part_226413_1101864383.1505469984034--


### PR DESCRIPTION
This is PR #159 with the whitespace build fixes rebased into a single commit.