### PR TITLE
Fix attachments with apostrophe in the name (0'Reillybooks.txt)

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -476,14 +476,10 @@ class Parser
 
             if (isset($part['disposition-filename'])) {
                 $filename = $this->decodeHeader($part['disposition-filename']);
-                // Escape all potentially unsafe characters from the filename
-                $filename = preg_replace('((^\.)|\/|(\.$))', '_', $filename);
             } elseif (isset($part['content-name'])) {
                 // if we have no disposition but we have a content-name, it's a valid attachment.
                 // we simulate the presence of an attachment disposition with a disposition filename
                 $filename = $this->decodeHeader($part['content-name']);
-                // Escape all potentially unsafe characters from the filename
-                $filename = preg_replace('((^\.)|\/|(\.$))', '_', $filename);
                 $disposition = 'attachment';
             } elseif (in_array($part['content-type'], $non_attachment_types, true)
                 && $disposition !== 'attachment') {
@@ -504,6 +500,9 @@ class Parser
                 $contentidAttachments = $this->getPart('content-id', $part);
 
                 $mimePartStr = $this->getPartComplete($part);
+
+                // Escape all potentially unsafe characters from the filename
+                $filename = preg_replace('((^\.)|\'|\/|(\.$))', '_', $filename);
 
                 $attachments[] = new Attachment(
                     $filename,

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -97,7 +97,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("attach_01", $attachments[0]->getFilename());
     }
 
-    public function testIlligalAttachmentFilenameWithApostrophes_ForDispositionFilename()
+    public function testIlligalAttachmentFilenameWithApostrophesForDispositionFilename()
     {
         $file = __DIR__ . '/mails/m0028';
         $Parser = new Parser();

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -97,6 +97,16 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("attach_01", $attachments[0]->getFilename());
     }
 
+    public function testIlligalAttachmentFilenameWithApostrophes_ForDispositionFilename()
+    {
+        $file = __DIR__ . '/mails/m0028';
+        $Parser = new Parser();
+        $Parser->setText(file_get_contents($file));
+        $attachments = $Parser->getAttachments(false);
+
+        $this->assertEquals("O_Reillybooks.txt", $attachments[0]->getFilename());
+    }
+
     public function testIlligalAttachmentFilenameForContentName()
     {
         $file = __DIR__ . '/mails/m0027';

--- a/tests/mails/m0028
+++ b/tests/mails/m0028
@@ -1,0 +1,7 @@
+Subject: 1234 / 1234
+To: <name@company.com>
+MIME-Version: 1.0
+Content-Type: application/txt;
+ name="O'Reillybooks.txt"
+Content-Transfer-Encoding: base64
+Content-Description: 1234 / 1234


### PR DESCRIPTION
Hi, 

Please, add apostrophe to the list of of illegal characters.

Remove duplicated code by filtering the filename once before creating the Attachment object. 