### PR TITLE
Save Attachment Enhancement.

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -151,10 +151,10 @@ class Attachment
      */
     protected function suffixFileName(string $dir, string $fileName): string
     {
-        $pathInfo = pathinfo($dir . DIRECTORY_SEPARATOR . $fileName);
-        $fileExtension = $pathInfo['extension'] ?? '';
-        if ($fileExtension != '') {
-            $fileExtension = '.'. $fileExtension;
+        $pathInfo       = pathinfo($dir . DIRECTORY_SEPARATOR . $fileName);
+        $fileExtension  = $pathInfo['extension'] ?? null;
+        if (null !== $fileExtension) {
+            $fileExtension = '.' . $pathInfo['extension'];
         }
         $i = 0;
         while (file_exists($dir . DIRECTORY_SEPARATOR . $fileName)) {

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -152,12 +152,16 @@ class Attachment
     protected function suffixFileName(string $dir, string $fileName): string
     {
         $pathInfo = pathinfo($dir . DIRECTORY_SEPARATOR . $fileName);
+        $fileExtension = $pathInfo['extension'] ?? '';
+        if ($fileExtension != '') {
+            $fileExtension = '.'. $fileExtension;
+        }
         $i = 0;
         while (file_exists($dir . DIRECTORY_SEPARATOR . $fileName)) {
-            if ($i++ <= 1000) {
-                $fileName = $pathInfo['filename'] . "_$i." . $pathInfo['extension'];
+            if ($i++ < 1000) {
+                $fileName = $pathInfo['filename'] . "_$i" . $fileExtension;
             } else {
-                $fileName = $pathInfo['filename'] . '_' . self::getRandomString() . $pathInfo['extension'];
+                $fileName = $pathInfo['filename'] . '_' . self::getRandomString() . $fileExtension;
             }
         }
         return $fileName;

--- a/tests/AttachmentTest.php
+++ b/tests/AttachmentTest.php
@@ -50,4 +50,30 @@ class AttachmentTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(1, $attachmentFiles);
     }
+
+    public function testSaveEachAttachmentDuplicateSuffix()
+    {
+        $file = __DIR__ . '/mails/m0002';
+        $Parser = new Parser();
+        $Parser->setPath($file);
+
+        $attachDir = __DIR__ . '/mails/m0002_attachments/';
+        $attachments = $Parser->getAttachments();
+
+        for ($i = 0; $i <= 1001; $i++) {
+            $attachments[0]->save($attachDir);
+        }
+
+        $filePath = "$attachDir/{$attachments[0]->getFilename()}";
+        $this->assertTrue(file_exists($filePath));
+        $this->assertTrue(file_exists("{$filePath}_1000"));
+
+        $attachmentFiles = glob($attachDir . '*');
+
+        // Clean up attachments dir
+        array_map('unlink', $attachmentFiles);
+        rmdir($attachDir);
+
+        $this->assertCount(1002, $attachmentFiles); //Original + 1000 suffixed + 1 random
+    }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -152,7 +152,7 @@ class ParserTest extends \PHPUnit\Framework\TestCase
         // Default: generate filename suffix, so we should have two files
         $this->assertEquals(2, count($attachmentFiles));
         $this->assertStringStartsWith(__DIR__ . '/mails/m0026_attachments/ATT00001.txt', $attachmentFiles[0]);
-        $this->assertStringStartsWith(__DIR__ . '/mails/m0026_attachments/ATT00001.txt', $attachmentFiles[1]);
+        $this->assertEquals(__DIR__ . '/mails/m0026_attachments/ATT00001_1.txt', $attachmentFiles[1]);
     }
 
     public function testAttachmentsWithWrongDirectory()
@@ -173,7 +173,7 @@ class ParserTest extends \PHPUnit\Framework\TestCase
         // Default: generate filename suffix, so we should have two files
         $this->assertEquals(2, count($attachmentFiles));
         $this->assertStringStartsWith(__DIR__ . '/mails/m0026_attachments/ATT00001.txt', $attachmentFiles[0]);
-        $this->assertStringStartsWith(__DIR__ . '/mails/m0026_attachments/ATT00001.txt', $attachmentFiles[1]);
+        $this->assertEquals(__DIR__ . '/mails/m0026_attachments/ATT00001_1.txt', $attachmentFiles[1]);
     }
 
     public function testAttachmentsWithDuplicatesRandom()
@@ -1755,7 +1755,7 @@ variances available &nbsp;</div></body></html>'
     {
 
         $middlewareCalled = false;
-        
+
         //Init
         $file = __DIR__.'/mails/m0001';
 
@@ -1792,7 +1792,7 @@ variances available &nbsp;</div></body></html>'
 
         // executes the middleware
         $middlewareStack->parse($mimePart);
-        
+
         $this->assertTrue($middlewareCallCount == 2, 'Middleware was was not called.');
     }
 


### PR DESCRIPTION
Instead of giving an attachment a unique filename and extension 'tmp'
when the original fileName already exists, the attachment is now saved
as the original fileName with a integer suffix and original extension.

When the suffix reaches the number 1000 and the fileName still already
exist, the fileName will be random and unique, but the extension still
remains the original one.