### PR TITLE
Charset decode: Ignore upper/lower case for mb_list_encoding() check

### DIFF
--- a/src/Charset.php
+++ b/src/Charset.php
@@ -320,7 +320,7 @@ class Charset implements CharsetManager
         } elseif (function_exists('mb_convert_encoding') && strtolower($charset) == 'iso-2022-jp') {
             return mb_convert_encoding($encodedString, 'UTF-8', 'ISO-2022-JP-MS');
         } elseif (function_exists('mb_convert_encoding')
-        	&& array_search(strtolower($charset), array_map('strtolower', mb_list_encodings())) !== false
+            && array_search(strtolower($charset), array_map('strtolower', mb_list_encodings())) !== false
         ) {
             return mb_convert_encoding($encodedString, 'UTF-8', $charset);
         } else {

--- a/src/Charset.php
+++ b/src/Charset.php
@@ -319,7 +319,9 @@ class Charset implements CharsetManager
             return $encodedString;
         } elseif (function_exists('mb_convert_encoding') && strtolower($charset) == 'iso-2022-jp') {
             return mb_convert_encoding($encodedString, 'UTF-8', 'ISO-2022-JP-MS');
-        } elseif (function_exists('mb_convert_encoding') && array_search(strtolower($charset), array_map('strtolower', mb_list_encodings())) !== false) {
+        } elseif (function_exists('mb_convert_encoding')
+        	&& array_search(strtolower($charset), array_map('strtolower', mb_list_encodings())) !== false
+        ) {
             return mb_convert_encoding($encodedString, 'UTF-8', $charset);
         } else {
             return iconv($this->getCharsetAlias($charset), 'UTF-8//TRANSLIT//IGNORE', $encodedString);

--- a/src/Charset.php
+++ b/src/Charset.php
@@ -319,8 +319,8 @@ class Charset implements CharsetManager
             return $encodedString;
         } elseif (function_exists('mb_convert_encoding') && strtolower($charset) == 'iso-2022-jp') {
             return mb_convert_encoding($encodedString, 'UTF-8', 'ISO-2022-JP-MS');
-        } elseif (function_exists('mb_convert_encoding') && array_search($charset, mb_list_encodings()) !== false) {
-            return mb_convert_encoding($encodedString, 'UTF-8', $this->getCharsetAlias($charset));
+        } elseif (function_exists('mb_convert_encoding') && array_search(strtolower($charset), array_map('strtolower', mb_list_encodings())) !== false) {
+            return mb_convert_encoding($encodedString, 'UTF-8', $charset);
         } else {
             return iconv($this->getCharsetAlias($charset), 'UTF-8//TRANSLIT//IGNORE', $encodedString);
         }


### PR DESCRIPTION
Currently, many charsets (like windows-1251) don't work properly with mb_convert_encoding() because the case is different (like Windows-1251)
Furthermore I removed the getCharsetAlias() call, because the method was already called in Parser.php.