### PR TITLE
Fix missing checks on escaping all potentially unsafe characters from the filename

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -514,14 +514,10 @@ class Parser
 
             if (isset($part['disposition-filename'])) {
                 $filename = $this->decodeHeader($part['disposition-filename']);
-                // Escape all potentially unsafe characters from the filename
-                $filename = preg_replace('((^\.)|\/|(\.$))', '_', $filename);
             } elseif (isset($part['content-name'])) {
                 // if we have no disposition but we have a content-name, it's a valid attachment.
                 // we simulate the presence of an attachment disposition with a disposition filename
                 $filename = $this->decodeHeader($part['content-name']);
-                // Escape all potentially unsafe characters from the filename
-                $filename = preg_replace('((^\.)|\/|(\.$))', '_', $filename);
                 $disposition = 'attachment';
             } elseif (in_array($part['content-type'], $non_attachment_types, true)
                 && $disposition !== 'attachment') {
@@ -540,6 +536,9 @@ class Parser
                 if ($filename == 'noname') {
                     $nonameIter++;
                     $filename = 'noname'.$nonameIter;
+                } else {
+                    // Escape all potentially unsafe characters from the filename
+                    $filename = preg_replace('((^\.)|\/|[\n|\r|\n\r]|(\.$))', '_', $filename);
                 }
 
                 $headersAttachments = $this->getPart('headers', $part);


### PR DESCRIPTION
Reference to my bug report on #250

I've updated the regex from `((^\.)|\/|(\.$))` to `((^\.)|\/|[\n|\r|\n\r]|(\.$))` (Extending it with `[\n|\r|\n\r]`). Test of the regex can be found here https://regex101.com/r/aEkWpt/2

To avoid missing one of the regex's next time I've centralized them within an `else` statement to not run it on non-matched filenames.

I've tested the code, please make sure you can reproduce the issue and that my PR fixes the issue.

Thanks.