### PR TITLE
Do not test with lowest dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         php: [7.2, 7.3, 7.4]
-        dependency-version: [prefer-lowest, prefer-stable]
+        dependency-version: [prefer-stable]
     steps:
       - name: Checkout code
         uses: actions/checkout@v1


### PR DESCRIPTION
The package only depends on PHP and the extension, which are not installed with composer, therefore `--prefer-lowest` has no effect on them, and adds no value.