### PR TITLE
Simplify temporary directory handling and fopen()-related tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,9 +54,9 @@
     },
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/php-token-stream": "^3.0",
         "phpunit/phpunit": "^8.0",
-        "squizlabs/php_codesniffer": "^3.5"
+        "squizlabs/php_codesniffer": "^3.5",
+        "symfony/filesystem": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
          colors="true">
 
     <testsuites>
-        <testsuite name="eXorus PhpMimeMailParser Test Suite">
+        <testsuite name="PhpMimeMailParser Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="vendor/autoload.php">
-    <testsuite name="eXorus PhpMimeMailParser Test Suite">
-        <directory suffix="Test.php">tests</directory>
-    </testsuite>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         executionOrder="random"
+         resolveDependencies="true"
+         colors="true">
+
+    <testsuites>
+        <testsuite name="eXorus PhpMimeMailParser Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -263,7 +263,7 @@ class Attachment
         }
 
         /** @var resource $fp */
-        if ($fp = fopen($attachment_path, 'w')) {
+        if ($fp = @fopen($attachment_path, 'w')) {
             while ($bytes = $this->read()) {
                 fwrite($fp, $bytes);
             }

--- a/tests/AttachmentTest.php
+++ b/tests/AttachmentTest.php
@@ -17,15 +17,11 @@ class AttachmentTest extends TestCase
         $Parser = new Parser();
         $Parser->setPath($file);
 
-        $attachDir = __DIR__ . '/mails/m0002_attachments/';
+        $attachDir = $this->tempdir('m0002_attachments');
+
         $Parser->saveAttachments($attachDir);
 
         $attachmentFiles = glob($attachDir . '*');
-
-        // Clean up attachments dir
-        array_map('unlink', $attachmentFiles);
-        rmdir($attachDir);
-
         $this->assertCount(1, $attachmentFiles);
     }
 
@@ -35,17 +31,13 @@ class AttachmentTest extends TestCase
         $Parser = new Parser();
         $Parser->setPath($file);
 
-        $attachDir = __DIR__ . '/mails/m0002_attachments/';
+        $attachDir = $this->tempdir('m0002_attachments');
+
         foreach ($Parser->getAttachments() as $attachment) {
             $attachment->save($attachDir);
         }
 
         $attachmentFiles = glob($attachDir . '*');
-
-        // Clean up attachments dir
-        array_map('unlink', $attachmentFiles);
-        rmdir($attachDir);
-
         $this->assertCount(1, $attachmentFiles);
     }
 
@@ -55,7 +47,8 @@ class AttachmentTest extends TestCase
         $Parser = new Parser();
         $Parser->setPath($file);
 
-        $attachDir = __DIR__ . '/mails/m0002_attachments/';
+        $attachDir = $this->tempdir('m0002_attachments');
+
         $attachments = $Parser->getAttachments();
 
         $attachments[0]->maxDuplicateNumber = 5;
@@ -75,10 +68,6 @@ class AttachmentTest extends TestCase
         $this->assertFileExists($attachDir . 'attach02_4');
         $this->assertFileExists($attachDir . 'attach02_5');
         $this->assertFileNotExists($attachDir . 'attach02_6');
-
-        // Clean up attachments dir
-        array_map('unlink', $attachmentFiles);
-        rmdir($attachDir);
     }
 
     public function testGeneratingDuplicateSuffix()
@@ -87,7 +76,8 @@ class AttachmentTest extends TestCase
         $Parser = new Parser();
         $Parser->setPath($file);
 
-        $attachDir = __DIR__ . '/mails/issue115_attachments/';
+        $attachDir = $this->tempdir('issue115_attachments');
+
         $attachments = $Parser->getAttachments();
 
         $attachments[0]->maxDuplicateNumber = 3;
@@ -105,10 +95,6 @@ class AttachmentTest extends TestCase
         $this->assertFileExists($attachDir . 'logo_2.jpg');
         $this->assertFileExists($attachDir . 'logo_3.jpg');
         $this->assertFileNotExists($attachDir . 'logo_4.jpg');
-
-        // Clean up attachments dir
-        array_map('unlink', $attachmentFiles);
-        rmdir($attachDir);
     }
 
     public function testSavingWithRandomFilenameKeepExtension()
@@ -117,16 +103,13 @@ class AttachmentTest extends TestCase
         $Parser = new Parser();
         $Parser->setPath($file);
 
-        $attachDir = __DIR__ . '/mails/m0025_attachments/';
+        $attachDir = $this->tempdir('m0025_attachments');
+
         $Parser->saveAttachments($attachDir, true, $Parser::ATTACHMENT_RANDOM_FILENAME);
 
         $attachmentFiles = glob($attachDir . '*');
         $attachmentJpgFiles = glob($attachDir . '*.jpg');
         $attachmentTxtFiles = glob($attachDir . '*.txt');
-
-        // Clean up attachments dir
-        array_map('unlink', $attachmentFiles);
-        rmdir($attachDir);
 
         $this->assertCount(3, $attachmentFiles);
         $this->assertCount(2, $attachmentJpgFiles);

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -13,15 +13,12 @@ use PhpMimeMailParser\Exception;
  */
 class ExceptionTest extends TestCase
 {
-    public function setUp(): void
+    protected function tearDown(): void
     {
         global $mockTmpFile;
         $mockTmpFile = false;
 
-        global $mockFopen;
-        $mockFopen = false;
-
-        parent::setUp();
+        parent::tearDown();
     }
 
     /**
@@ -162,13 +159,11 @@ class ExceptionTest extends TestCase
 
         $mid = 'm0001';
         $file = __DIR__.'/mails/'.$mid;
-        $attach_dir = __DIR__.'/mails/attach_'.$mid.'/';
+        $attach_dir = $this->tempdir('attach_'.$mid);
+        chmod($attach_dir, 0600);
 
         $Parser = new Parser();
         $Parser->setStream(fopen($file, 'r'));
-
-        global $mockFopen;
-        $mockFopen = true;
 
         $Parser->saveAttachments($attach_dir);
     }
@@ -182,20 +177,12 @@ class ExceptionTest extends TestCase
 
         $mid = 'm0026';
         $file = __DIR__ . '/mails/' . $mid;
-        $attach_dir = __DIR__ . '/mails/attach_' . $mid . '/';
+        $attach_dir = $this->tempdir('attach_' . $mid);
 
         $Parser = new Parser();
         $Parser->setText(file_get_contents($file));
 
-        try {
-            $Parser->saveAttachments($attach_dir, false, Parser::ATTACHMENT_DUPLICATE_THROW);
-        } catch (Exception $e) {
-            // Clean up attachments dir
-            unlink($attach_dir . 'ATT00001.txt');
-            rmdir($attach_dir);
-
-            throw $e;
-        }
+        $Parser->saveAttachments($attach_dir, false, Parser::ATTACHMENT_DUPLICATE_THROW);
     }
 
     /**

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -149,14 +149,10 @@ class ParserTest extends TestCase
         $Parser = new Parser();
         $Parser->setText(file_get_contents($file));
 
-        $attachDir = __DIR__ . '/mails/m0026_attachments/';
+        $attachDir = $this->tempdir('m0002_attachments');
         $Parser->saveAttachments($attachDir, false);
 
         $attachmentFiles = glob($attachDir . '*');
-
-        // Clean up attachments dir
-        array_map('unlink', $attachmentFiles);
-        rmdir($attachDir);
 
         // Default: generate filename suffix, so we should have two files
         $this->assertCount(2, $attachmentFiles);
@@ -170,14 +166,10 @@ class ParserTest extends TestCase
         $Parser = new Parser();
         $Parser->setText(file_get_contents($file));
 
-        $attachDir = __DIR__ . '/mails/m0026_attachments/';
+        $attachDir = $this->tempdir('m0026_attachments');
         $Parser->saveAttachments($attachDir, false, Parser::ATTACHMENT_RANDOM_FILENAME);
 
         $attachmentFiles = glob($attachDir . '*');
-
-        // Clean up attachments dir
-        array_map('unlink', $attachmentFiles);
-        rmdir($attachDir);
 
         // Default: generate random filename, so we should have two files
         $this->assertCount(2, $attachmentFiles);
@@ -1146,7 +1138,7 @@ class ParserTest extends TestCase
     ) {
         //Init
         $file = __DIR__.'/mails/'.$mid;
-        $attach_dir = __DIR__.'/mails/attach_'.$mid.'/';
+        $attach_dir = $this->tempdir('attach_'.$mid);
 
         //Load From Path
         $Parser = new Parser();
@@ -1241,13 +1233,8 @@ class ParserTest extends TestCase
                     array_push($attachmentsEmbeddedToCheck, $attachmentExpected[7]);
                 }
 
-                //Remove Attachment
-                unlink($attach_dir.$attachments[$iterAttachments]->getFilename());
-
                 $iterAttachments++;
             }
-            //Remove Attachment Directory
-            rmdir($attach_dir);
         } else {
             $this->assertEquals([], $Parser->saveAttachments($attach_dir));
         }
@@ -1280,7 +1267,7 @@ class ParserTest extends TestCase
     ) {
         //Init
         $file = __DIR__.'/mails/'.$mid;
-        $attach_dir = __DIR__.'/mails/attach_'.$mid.'/';
+        $attach_dir = $this->tempdir('attach_'.$mid);
 
         //Load From Text
         $Parser = new Parser();
@@ -1375,13 +1362,8 @@ class ParserTest extends TestCase
                     array_push($attachmentsEmbeddedToCheck, $attachmentExpected[7]);
                 }
 
-                //Remove Attachment
-                unlink($attach_dir.$attachments[$iterAttachments]->getFilename());
-
                 $iterAttachments++;
             }
-            //Remove Attachment Directory
-            rmdir($attach_dir);
         } else {
             $this->assertEquals([], $Parser->saveAttachments($attach_dir));
         }
@@ -1415,7 +1397,8 @@ class ParserTest extends TestCase
     ) {
         //Init
         $file = __DIR__.'/mails/'.$mid;
-        $attach_dir = __DIR__.'/mails/attach_'.$mid.'/';
+        $attach_dir = $this->tempdir('attach_'.$mid);
+
 
         //Load From Path
         $Parser = new Parser();
@@ -1510,13 +1493,8 @@ class ParserTest extends TestCase
                     array_push($attachmentsEmbeddedToCheck, $attachmentExpected[7]);
                 }
 
-                //Remove Attachment
-                unlink($attach_dir.$attachments[$iterAttachments]->getFilename());
-
                 $iterAttachments++;
             }
-            //Remove Attachment Directory
-            rmdir($attach_dir);
         } else {
             $this->assertEquals([], $Parser->saveAttachments($attach_dir));
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,13 +1,42 @@
 <?php
 namespace Tests\PhpMimeMailParser;
 
+use Symfony\Component\Filesystem\Filesystem;
+
 /**
  * Test case of php-mime-mail-parser
  */
-class TestCase extends \PHPUnit\Framework\TestCase
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
-    public function setUp(): void
+    private $pathsToRemove = [];
+
+    protected function setUp(): void
     {
         // Common setup procedures
+    }
+
+    protected function tempdir(string $prefix = ''): string
+    {
+        do {
+            $tempnam = tempnam(sys_get_temp_dir(), 'php-mime-mail-parser_' . $prefix);
+            unlink($tempnam);
+
+            if (@mkdir($tempnam, 0700)) {
+                break;
+            }
+        } while (true);
+
+        $this->pathsToRemove[] = $tempnam;
+
+        // Other code expects this to end with a slash.
+        return $tempnam . DIRECTORY_SEPARATOR;
+    }
+
+    protected function tearDown(): void
+    {
+        $filesystem = new Filesystem();
+        $filesystem->remove($this->pathsToRemove);
+
+        $this->pathsToRemove = [];
     }
 }

--- a/tests/globals.php
+++ b/tests/globals.php
@@ -3,7 +3,6 @@
 namespace {
     // This allow us to configure the behavior of the "global mock"
     $mockTmpFile = false;
-    $mockFopen = false;
 }
 
 namespace PhpMimeMailParser {
@@ -14,16 +13,6 @@ namespace PhpMimeMailParser {
             return false;
         } else {
             return call_user_func_array('\tmpfile', func_get_args());
-        }
-    }
-
-    function fopen()
-    {
-        global $mockFopen;
-        if (isset($mockFopen) && $mockFopen === true) {
-            return false;
-        } else {
-            return call_user_func_array('\fopen', func_get_args());
         }
     }
 }


### PR DESCRIPTION
Fixed issues:

 - Failing tests were not always cleaning up behind them, which required manual cleanup.
 - `fopen` error handling test was failing on actual fopen errors because they're causing warnings.
 - Mock variables weren't reset for failing tests, leading to more failures. 

Implementation notes:

 - Luckily there weren't any hidden dependencies between tests. `executionOrder="random"` ensures there won't be any.
 - `symfony/filesystem` greatly simplifies cleanup, and it's only a dev-dependency.