### PR TITLE
Update secret name for codecov.io

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,4 +60,4 @@ jobs:
       - name: Execute code coverage
         run: |
           composer test-with-coverage
-          bash <(curl -s https://codecov.io/bash) -t ${{ secrets.COVERALLS_REPO_TOKEN }}
+          bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_REPO_TOKEN }}


### PR DESCRIPTION
It seems like a codecov token is [missing from settings](https://github.com/php-mime-mail-parser/php-mime-mail-parser/settings/secrets), and that's [what it says](https://github.com/php-mime-mail-parser/php-mime-mail-parser/runs/427745505#step:5:48). Coveralls is a different service, which means that a token for a different service might be a problem.

This PR changes to token to `CODECOV_REPO_TOKEN`, but I can't update it in the settings.