### PR TITLE
Improve coverage for getPartCharset

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -719,11 +719,7 @@ class Parser
      */
     protected function getPartCharset($part)
     {
-        if (isset($part['charset'])) {
-            return $this->charset->getCharsetAlias($part['charset']);
-        } else {
-            return 'us-ascii';
-        }
+        return $this->charset->getCharsetAlias($part['charset']);
     }
 
     /**


### PR DESCRIPTION
[Looking at the code of the extension](https://github.com/php/pecl-mail-mailparse/blob/9efc0652bd40c58556819a986e9cdbadc9ac5860/mailparse.c#L1452) it can be seen that there's always a charset.