### PR TITLE
Enforce coverage level during CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,3 +61,4 @@ jobs:
         run: |
           composer test-with-coverage
           bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_REPO_TOKEN }}
+          php vendor/bin/coverage-check coverage.xml 100

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,10 @@ jobs:
         run: composer update --prefer-dist --no-interaction --no-suggest --no-progress
 
       - name: Execute code coverage
-        run: |
-          composer test-with-coverage
-          bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_REPO_TOKEN }}
-          php vendor/bin/coverage-check coverage.xml 100
+        run: composer test-with-coverage
+
+      - name: Upload code coverage
+        run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_REPO_TOKEN }}
+
+      - name: Check code coverage
+        run: php vendor/bin/coverage-check coverage.xml 100

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,8 @@ jobs:
         run: composer test-with-coverage
 
       - name: Upload code coverage
-        run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_REPO_TOKEN }}
+        continue-on-error: true
+        run: bash <(curl -s https://codecov.io/bash) -Z -t ${{ secrets.CODECOV_REPO_TOKEN }}
 
       - name: Check code coverage
         run: php vendor/bin/coverage-check coverage.xml 100

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,11 +62,10 @@ jobs:
         run: composer test-with-coverage
 
       - name: Upload code coverage
-        env:
-          CODECOV_REPO_TOKEN: ${{ secrets.CODECOV_REPO_TOKEN }}
-        if: env.CODECOV_REPO_TOKEN
-        continue-on-error: true
-        run: bash <(curl -s https://codecov.io/bash) -Z -t ${{ secrets.CODECOV_REPO_TOKEN }}
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_REPO_TOKEN }}
+          fail_ci_if_error: true
 
       - name: Check code coverage
         run: php vendor/bin/coverage-check coverage.xml 100

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,9 @@ jobs:
         run: composer test-with-coverage
 
       - name: Upload code coverage
+        env:
+          CODECOV_REPO_TOKEN: ${{ secrets.CODECOV_REPO_TOKEN }}
+        if: env.CODECOV_REPO_TOKEN
         continue-on-error: true
         run: bash <(curl -s https://codecov.io/bash) -Z -t ${{ secrets.CODECOV_REPO_TOKEN }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,7 @@ jobs:
         run: composer test-with-coverage
 
       - name: Upload code coverage
+        if: env.CODECOV_REPO_TOKEN
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_REPO_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,8 @@ jobs:
         uses: shivammathur/setup-php@v1
         with:
           php-version: 7.4
-          extensions: mailparse
+          extensions: mailparse, mbstring
+          coverage: pcov
 
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-suggest --no-progress

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.2",
         "phpunit/phpunit": "^8.0",
+        "rregeer/phpunit-coverage-check": "^0.3.1",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/filesystem": "^5.0"
     },
@@ -76,7 +77,7 @@
             "vendor/bin/phpunit"
         ],
         "test-with-coverage": [
-            "vendor/bin/phpunit --coverage-clover=coverage.xml --whitelist src"
+            "vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml"
         ]
     }
 }


### PR DESCRIPTION
- [x] Enable mbstring for more complete coverage
- [x] Use PCOV for faster reporting
- [x] Do not upload coverage if there's no token (e.g. in PR builds)


I think we still don't get PR [coverage reports uploaded to codecov.io properly](https://codecov.io/gh/php-mime-mail-parser/php-mime-mail-parser/commits), and I'm not even sure this is possible, so at least we'll have this safeguard.

TBH I'm not a big fan of codecov.io, and I'd rather use something else like [Coveralls](https://coveralls.io/), but codecov kinda works and free, so it's better them rather than nothing else.
