### PR TITLE
Parser::fromStream(): do not close stream

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -129,8 +129,6 @@ final class Parser implements ParserInterface
         fseek($tmpFp, 0);
         $parser->stream = &$tmpFp;
 
-        fclose($stream);
-
         $parser->resource = mailparse_msg_create();
         // parses the message incrementally (low memory usage but slower)
         while (!feof($parser->stream)) {


### PR DESCRIPTION
This method closes stream that came in parameter. But the same stream is used later in Attachment object, which causes error:

```
stream_get_contents(): supplied resource is not a valid stream resource
```

This method should not close stream that received in parameter.

See detailed explanation in issue: https://github.com/php-mime-mail-parser/php-mime-mail-parser/issues/349#issuecomment-1084327734