### PR TITLE
fix "must be of type resource, bool given" error

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -177,6 +177,9 @@ final class Parser implements ParserInterface
      */
     private function parse(): void
     {
+        if (!$this->resource) {
+            return;
+        }
         $structure = mailparse_msg_get_structure($this->resource);
         $this->entities = [];
 


### PR DESCRIPTION
If the mail file could not be parsed (for example because of "MAXPARTS 300" which gives a warning and does not throw error) the code here gives "must be of type resource, bool given" in php8.1