### PR TITLE
Fix encoding from Windows-based software products

### DIFF
--- a/src/Charset.php
+++ b/src/Charset.php
@@ -320,6 +320,23 @@ class Charset implements CharsetManager
         if ($charset == 'utf-8' || $charset == 'us-ascii') {
             return $encodedString;
         }
+        
+        // Handle gb2312 from Windows-based software products
+        if ($charset === 'gb2312') {
+            // Make possible E_NOTICE error triggered by iconv silent
+            $currentErrorReporting = error_reporting();
+            error_reporting($currentErrorReporting ^ E_NOTICE);
+            
+            $result = iconv($charset, 'utf-8', $encodedString);
+            
+            error_reporting($currentErrorReporting);
+            
+            if ($result) {
+                return $result;
+            }
+            
+            $charset = 'gbk'; // If decoding from gb2312 failed, use gbk instead
+        }
 
         if (function_exists('mb_convert_encoding')) {
             if ($charset == 'iso-2022-jp') {

--- a/src/Charset.php
+++ b/src/Charset.php
@@ -323,9 +323,9 @@ class Charset implements CharsetManager
         
         // Handle gb2312 from Windows-based software products
         if ($charset === 'gb2312') {
-            // Make possible E_NOTICE error triggered by iconv silent
+            // Disable E_NOTICE errors to ignore E_NOTICE possibly triggered by iconv()
             $currentErrorReporting = error_reporting();
-            error_reporting($currentErrorReporting ^ E_NOTICE);
+            error_reporting($currentErrorReporting & ~E_NOTICE);
             
             $result = iconv($charset, 'utf-8', $encodedString);
             

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1900,7 +1900,7 @@ mini plain body';
         $Parser = new Parser();
         $Parser->setPath($file);
         $this->assertEquals('<foo@bar.de>', $Parser->getHeader('from'));
-        $this->assertStringContainsString('次の受信者またはグル?プへの配信に失?', $Parser->getMessageBody('text'));
+        $this->assertStringContainsString('次の受信者またはグル?プへの配信に失:', $Parser->getMessageBody('text'));
     }
 
     public function testCharsetNotSupportedByMBString()

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1900,7 +1900,7 @@ mini plain body';
         $Parser = new Parser();
         $Parser->setPath($file);
         $this->assertEquals('<foo@bar.de>', $Parser->getHeader('from'));
-        $this->assertStringContainsString('次の受信者またはグル?プへの配信に失:', $Parser->getMessageBody('text'));
+        $this->assertStringContainsString('次の受信者またはグループへの配信に失敗しました:', $Parser->getMessageBody('text'));
     }
 
     public function testCharsetNotSupportedByMBString()


### PR DESCRIPTION
There is an issue concerning the simplified chinese encoding. As explained in this article (https://en.wikipedia.org/wiki/Code_page_936_(Microsoft_Windows)), there is a confusion between GB2312, CP936 and GBK with Windows-based software products.

In my case, my application fetches an email from outlook.office365 with the header "Content-Type: text/html; charset="gb2312"". But decoding with "gb2312" does not work, and I have to decode with gbk. That works perfectly.

If you have a better solution that the one I propose, feel free to improve it :)