### PR TITLE
Make sure deprecations are visible when running the unit tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,4 +3,7 @@
     <testsuite name="eXorus PhpMimeMailParser Test Suite">
         <directory suffix="Test.php">tests</directory>
     </testsuite>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
 </phpunit>


### PR DESCRIPTION
This change sets [error_reporting to E_ALL](https://www.php.net/manual/en/function.error-reporting.php) [0] when running the test suite. This way we are sure that all notices and deprecations are visible.

Related to #413.