### PR TITLE
Narrow `Parser::getHeader()` return type

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -246,7 +246,7 @@ class Parser
      *
      * @param string $name Header name (case-insensitive)
      *
-     * @return string|bool
+     * @return string|false
      */
     public function getHeader($name)
     {


### PR DESCRIPTION
`Parser::getHeader()` only returns a string or boolean false, so narrowing the return to only specify false creates a minor DX improvement as analysis tools won't raise a warning if not checking for a boolean true return.