### PR TITLE
Added 'Custom Filename' attachment type

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -229,7 +229,8 @@ class Attachment
      */
     public function save(
         $attach_dir,
-        $filenameStrategy = Parser::ATTACHMENT_DUPLICATE_SUFFIX
+        $filenameStrategy = Parser::ATTACHMENT_DUPLICATE_SUFFIX,
+        $attach_filename = null
     ) {
         $attach_dir = rtrim($attach_dir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
         if (!is_dir($attach_dir)) {
@@ -238,6 +239,11 @@ class Attachment
 
         // Determine filename
         switch ($filenameStrategy) {
+            case Parser::ATTACHMENT_CUSTOM_FILENAME:
+                if (!empty($attach_filename)) {
+                    $attachment_path = $attach_dir.$attach_filename;
+                    break;
+                }
             case Parser::ATTACHMENT_RANDOM_FILENAME:
                 $fileInfo = pathinfo($this->getFilename());
                 $extension  = empty($fileInfo['extension']) ? '' : '.'.$fileInfo['extension'];

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -18,6 +18,7 @@ class Parser
     const ATTACHMENT_DUPLICATE_THROW  = 'DuplicateThrow';
     const ATTACHMENT_DUPLICATE_SUFFIX = 'DuplicateSuffix';
     const ATTACHMENT_RANDOM_FILENAME  = 'RandomFilename';
+    const ATTACHMENT_CUSTOM_FILENAME  = 'CustomFilename';
 
     /**
      * PHP MimeParser Resource ID


### PR DESCRIPTION
Added 'Custom Filename' to Attachment save.

Example:
  $attachment->save(__DIR__, PhpMimeMailParser\Parser::ATTACHMENT_CUSTOM_FILENAME, 'myFile.txt');

