### PR TITLE
Fix deprecation warning in PHP 8.4

### DIFF
--- a/src/MiddlewareStack.php
+++ b/src/MiddlewareStack.php
@@ -29,7 +29,7 @@ class MiddlewareStack
      *
      * @param Middleware $middleware
      */
-    public function __construct(MiddleWareContracts $middleware = null)
+    public function __construct(?MiddleWareContracts $middleware = null)
     {
         $this->middleware = $middleware;
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -74,7 +74,7 @@ class Parser
      *
      * @param CharsetManager|null $charset
      */
-    public function __construct(CharsetManager $charset = null)
+    public function __construct(?CharsetManager $charset = null)
     {
         if ($charset == null) {
             $charset = new Charset();


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types deprecates implicit nullable parameter types in PHP 8.4