### PR TITLE
PHP 8.5 Support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
         dependency-version: [prefer-lowest, prefer-stable]
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        php: [8.5]
         dependency-version: [prefer-lowest, prefer-stable]
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3, 8.4]
+        php: [8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
         dependency-version: [prefer-lowest, prefer-stable]
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The following versions of PHP are supported:
 * PHP 8.2
 * PHP 8.3
 * PHP 8.4
+* PHP 8.5
 
 Previous Versions:
 

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "ext-mailparse": "*"
     },
     "require-dev": {
-        "phpunit/phpunit":              "^10.0",
+        "phpunit/phpunit":              "^13.0",
         "php-coveralls/php-coveralls":  "^2.2",
         "squizlabs/php_codesniffer":    "^3.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "php-mime-mail-parser/php-mime-mail-parser",
     "type": "library",
-    "description": "A fully tested email parser for PHP 8.0+ (mailparse extension wrapper).",
+    "description": "A fully tested email parser for PHP 8.1+ (mailparse extension wrapper).",
     "keywords": ["mime", "mail", "mailparse", "MimeMailParser", "parser", "php"],
     "homepage": "https://github.com/php-mime-mail-parser/php-mime-mail-parser",
     "license": "MIT",
@@ -42,11 +42,11 @@
         "url":"https://github.com/php-mime-mail-parser/php-mime-mail-parser.git"
     },
     "require": {
-        "php":           "^8.0",
+        "php":           "^8.1",
         "ext-mailparse": "*"
     },
     "require-dev": {
-        "phpunit/phpunit":              "^9.6.22",
+        "phpunit/phpunit":              "^10.0",
         "php-coveralls/php-coveralls":  "^2.2",
         "squizlabs/php_codesniffer":    "^3.5"
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Supported PHP versions updated: added PHP 8.5 and raised minimum required PHP to 8.1.

* **Chores**
  * CI now runs tests only on PHP 8.5.
  * Development tooling updated: PHPUnit upgraded to v13.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->