### PR TITLE
Specify mailparse extension version in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mailparse-3.1.9
+          extensions: mailparse-3.2.0
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mailparse
+          extensions: mailparse-3.2.0
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mailparse-3.1.8
+          extensions: mailparse-3.1.9
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,6 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
         dependency-version: [prefer-lowest, prefer-stable]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
         dependency-version: [prefer-lowest, prefer-stable]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mailparse-3.2.0
+          extensions: mailparse-3.1.8
           coverage: none
 
       - name: Install dependencies

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -248,14 +248,13 @@ namespace PhpMimeMailParser {
 
         public function testMIMEMessageCannotBeParsedWithPath()
         {
+            $this->expectException(Exception::class);
+            $this->expectExceptionMessage('MIME message cannot be parsed');
+            
             $file = __DIR__ . '/mails/issue408.eml';
 
             $Parser = new Parser();
             $Parser->setPath($file);
-
-            $this->assertNotNull($Parser);
-            $Attachments = $Parser->getAttachments();
-            $this->assertGreaterThan(0, count($Attachments));
         }
     }
 }

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -248,10 +248,6 @@ namespace PhpMimeMailParser {
 
         public function testMIMEMessageCannotBeParsedWithPath()
         {
-            // Upstream mailparse bug: mailparse_msg_parse_file() fails on this complex MIME,
-            // while mailparse_msg_parse() succeeds with the same email content.
-            $this->markTestSkipped('Known upstream mailparse issue with mailparse_msg_parse_file() on issue408.eml');
-
             $file = __DIR__ . '/mails/issue408.eml';
 
             $Parser = new Parser();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tests updated to explicitly detect and fail on unparseable MIME messages, improving detection of malformed email inputs.

* **Chores**
  * CI environment pinned to a specific mail parsing extension version to ensure consistent test outcomes across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->